### PR TITLE
feat: compile with compiler macro to include system header

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -62,6 +62,9 @@
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.650968800" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER.871043587" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE.273766878" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="SYSTEM_APP_ID=_OBC_APP_ID_"/>
+								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS.1854939626" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS.603358553" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS.67536565" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS"/>
@@ -155,7 +158,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="libcsp/src/drivers/can/can_socketcan.c|libcsp/src/drivers/usart/usart_linux.c|libcsp/src/drivers/usart/usart_windows.c|libcsp/examples|libcsp/src/rtable/csp_rtable_cidr.c|libcsp/src/arch/windows|libcsp/src/arch/macosx|ex2_services/ex2_demo_software|libcsp/src/interfaces/csp_if_zmqhub.c|libcsp/src/arch/posix|ex2_services/Platform/demo|libcsp/src/bindings" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="ex2_services/Platform/demo|libcsp/src/drivers/can/can_socketcan.c|libcsp/src/drivers/usart/usart_linux.c|libcsp/src/drivers/usart/usart_windows.c|libcsp/examples|libcsp/src/rtable/csp_rtable_cidr.c|libcsp/src/arch/windows|libcsp/src/arch/macosx|ex2_services/ex2_demo_software|libcsp/src/interfaces/csp_if_zmqhub.c|libcsp/src/arch/posix|libcsp/src/bindings" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>


### PR DESCRIPTION
Changes to accommodate the `SYSTEM_APP_ID` compiler macro to compile for Docker, or OBC.