### PR TITLE
Init refactor

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -59,6 +59,7 @@
  */
 
 #define INIT_PRIO configMAX_PRIORITIES -1
+#define INIT_STACK_SIZE 1500
 
 static void init_filesystem();
 static void init_csp();
@@ -90,7 +91,7 @@ void ex2_init(void *pvParameters) {
 int ex2_main(void) {
     _enable_IRQ_interrupt_(); // enable inturrupts
     InitIO();
-    xTaskCreate(ex2_init, "init", 1500, NULL, INIT_PRIO, NULL);
+    xTaskCreate(ex2_init, "init", INIT_STACK_SIZE, NULL, INIT_PRIO, NULL);
     /* Start FreeRTOS! */
     vTaskStartScheduler();
 

--- a/main/main.c
+++ b/main/main.c
@@ -13,7 +13,7 @@
  */
 /**
  * @file main.c
- * @author Andrew Rooney, Haoran Qi
+ * @author Andrew Rooney, Haoran Qi, Robert Taylor, Dustin Wagner, Arash Yazdani
  * @date 2020-06-06
  */
 
@@ -58,7 +58,7 @@
  *  - Start the FreeRTOS scheduler
  */
 
-#define LEOP_SEQUENCE_TIMER_MS 10000
+#define INIT_PRIO configMAX_PRIORITIES -1
 
 static void init_filesystem();
 static void init_csp();
@@ -68,31 +68,33 @@ static void init_system_tasks();
 void vAssertCalled(unsigned long ulLine, const char *const pcFileName);
 static FTP ftp_app;
 
+void ex2_init(void *pvParameters) {
 
-int ex2_main(int argc, char **argv) {
+    /* Initialization routine */
+    //init_filesystem();
+    init_csp();
+    /* Start service server, and response server */
+    init_software();
 
-  const TickType_t leop_time_ms = pdMS_TO_TICKS(LEOP_SEQUENCE_TIMER_MS);
+  //  start_eps_mock();
+/*
+    void *task_handler = create_ftp_task(OBC_APP_ID, &ftp_app);
+    if (task_handler == NULL) {
+        return -1;
+    }
+*/
+    vTaskDelete(0); // delete self to free up heap
 
-  _enable_IRQ_interrupt_(); // enable inturrupts
-  InitIO();
+}
 
-  /* Initialization routine */
-  //init_filesystem();
-  init_csp();
-  /* Start service server, and response server */
-  init_software();
+int ex2_main(void) {
+    _enable_IRQ_interrupt_(); // enable inturrupts
+    InitIO();
+    xTaskCreate(ex2_init, "init", 1500, NULL, INIT_PRIO, NULL);
+    /* Start FreeRTOS! */
+    vTaskStartScheduler();
 
-//  start_eps_mock();
-
-  void *task_handler = create_ftp_task(OBC_APP_ID, &ftp_app);
-  if (task_handler == NULL) {
-      return -1;
-  }
-
-  /* Start FreeRTOS! */
-  vTaskStartScheduler();
-
-  for (;;); // Scheduler didn't start
+    for (;;); // Scheduler didn't start
 }
 
 /**

--- a/main/system.h
+++ b/main/system.h
@@ -84,7 +84,7 @@ typedef enum {
 #define DFGM_PWR_CHNL   1
 #define ADCS_PWR_CHNL   1
 
-int ex2_main(int argc, char **argv);
+int ex2_main(void);
 void SciSendBuf(char *buf, uint32_t bufSize);
 
 #endif /* SYSTEM_H */

--- a/source/HL_sys_link.cmd
+++ b/source/HL_sys_link.cmd
@@ -137,9 +137,8 @@ MEMORY
     #endif
 
     RAMINTVECS (RWX) : origin=0x08000000 length = 0x20
-    STACKS  (RW)     : origin=end(RAMINTVECS) length=0x00000800
-    KRAM    (RW)     : origin=end(STACKS) length=0x00000800
-    RAM     (RW)     : origin=end(KRAM)   length=0x0007f800 - 0x800 - 0x800 - 0x20
+    KRAM    (RW)     : origin=end(RAMINTVECS) length=0x00000800
+    RAM     (RW)     : origin=end(KRAM)   length=0x0007f800 - 0x400 - 0x800 - 0x20
 	SDRAM  (RWX) : origin=0x80000000 length=0x07FFFFFF//experimental
 
 }

--- a/source/HL_sys_main.c
+++ b/source/HL_sys_main.c
@@ -83,9 +83,8 @@ uint32 	emacPhyAddress	=	1U;
 int main(void)
 {
 /* USER CODE BEGIN (3) */
-    ex2_main(NULL, NULL);
-    for (;;);
-    return -1;
+    ex2_main();
+    systemREG1->SYSECR = (0x10) << 14; // Bootloops are bad but returning from main is worse
 /* USER CODE END */
 
     return 0;


### PR DESCRIPTION
Certain software expects to be run in a task context and not in main() such as reliance edge. Additionally, the new drivers we have been working on expect to take advantage of FreeRTOS features. 

We continually have stack overflow problems in main() and instead of solving that with a larger, wasteful stack, it is better to run in a task where the stack size can be adjusted. The memory allocated for the init task will be reclaimed when it deletes itself at the end of its run. 

The init task runs at the highest priority. If this is not enough to ensure adequate timing for a certain operation, the operation may be encased in a critical section. Formerly, main() could have been considered a really big critical section. 

Privileged operations cannot be done in the ex2_init task without making a corresponding privileged function. Simple privileged operations (such as InitIO) may be done in main. More complex privileged init operations should be done in a special privileged function. 