### PR TITLE
Include Sband EH and add conditions to beacon task

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -287,6 +287,9 @@
 					</folderInfo>
 					<sourceEntries>
 						<entry excluding="ex2_hal/ex2_adcs_software/equipment_handler/src/uart_i2c.c|ex2_hal/ex2_adcs_software/equipment_handler/test|test|ex2_services/Services/source/athena|ex2_services/Services/include/athena|ex2_ftp/Program/src/main.c|ex2_ftp/Program/test|ex2_hal/ex2_gps_software/ceedling-deprecated|ex2_hal/ex2_gps_software/test|libcsp/src/arch/macosx|libcsp/src/drivers/can/can_socketcan.c|ex2_services/ex2_demo_software|libcsp/src/drivers/usart/usart_linux.c|libcsp/src/drivers/usart/usart_windows.c|libcsp/examples|ex2_hal/ex2_sband_software/equipment_handler|libcsp/src/rtable/csp_rtable_cidr.c|libcsp/src/arch/posix|libcsp/src/arch/windows|libcsp/src/bindings" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/source"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/include"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/test"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="test/src"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="test/include"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/src"/>
@@ -597,6 +600,7 @@
 					</folderInfo>
 					<sourceEntries>
 						<entry excluding="ex2_services/Services/source/athena|ex2_services/Services/include/athena|libcsp/src/arch/macosx|libcsp/src/drivers/can/can_socketcan.c|ex2_services/ex2_demo_software|libcsp/src/drivers/usart/usart_linux.c|libcsp/src/drivers/usart/usart_windows.c|libcsp/examples|ex2_hal/ex2_sband_software/equipment_handler|libcsp/src/rtable/csp_rtable_cidr.c|libcsp/src/arch/posix|libcsp/src/arch/windows|libcsp/src/bindings" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/test"/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ex2_hal/ex2_sband_software/equipment_handler/src"/>
 					</sourceEntries>
 				</configuration>

--- a/ex2_system/source/beacon/beacon_task.c
+++ b/ex2_system/source/beacon/beacon_task.c
@@ -48,33 +48,31 @@ static void *beacon_daemon(void *pvParameters) {
     UHF_configStruct beacon_msg;
     // TODO: call the appropriate HAL functions to get the most updated or
     // cached information of the components + state machine, RTC, etc.
-
-    uhf_status = HAL_UHF_setBeaconMsg(beacon_msg);
+    // Then uncomment the next line:
+    //uhf_status = HAL_UHF_setBeaconMsg(beacon_msg);
 
     /* Sending the beacon */
     // The beacon transmission period is configurable through comms service
     // by the operator or here through HAL_UHF_getBeaconT().
     uint8_t scw[SCW_LEN];
-    uhf_status = HAL_UHF_getSCW(scw);
 #ifndef UHF_IS_STUBBED
+    uhf_status = HAL_UHF_getSCW(scw);
+
     if (uhf_status == U_GOOD_CONFIG) {
-#else
-    if (uhf_status == 0) {
-#endif
       scw[SCW_BCN_FLAG] = SCW_BCN_ON;
       uhf_status = HAL_UHF_setSCW(scw);
     }
-#ifndef UHF_IS_STUBBED
-    if (uhf_status != U_GOOD_CONFIG) {
-#else
-    if (uhf_status != 0) {
 #endif
+#ifndef EPS_IS_STUBBED
+    if (uhf_status != U_GOOD_CONFIG) {
+
       if (eps_get_pwr_chnl(UHF_PWR_CHNL) == 1 &&
           gioGetBit(UHF_GIO_PORT, UHF_GIO_PIN) == 1) {
         printf("Beacon failed");
       } else
         printf("UHF is off.");
     }
+#endif
 
     vTaskDelay(beacon_delay);
   }


### PR DESCRIPTION
The Sband equipment handler was excluded from the build which doesn't need to be once [this PR](https://github.com/AlbertaSat/ex2_sband_software/pull/9) is merged.
Fixes for beacon to not work unless both uhf and eps are connected. It stops attempts to print errors, now.