### PR TITLE
Change optimization level to -O3

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -75,7 +75,6 @@
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/include/ex2_os}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/housekeeping}"/>
-									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/ex2_demo_software}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/libcsp/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/include}"/>
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
@@ -102,6 +101,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.486947006" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER.700241837" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER" value="true" valueType="boolean"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.1597551648" name="C Dialect" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.C99" valueType="enumerated"/>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.284321430" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.3" valueType="enumerated"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS.514290555" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS.90709160" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS.1990194205" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS"/>
@@ -627,7 +627,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.984677102" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER.1634399590" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER" value="true" valueType="boolean"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.375711469" name="C Dialect" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.C99" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.1258982786" name="Optimization level (--opt_level, -O)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.off" valueType="enumerated"/>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.1258982786" name="Optimization level (--opt_level, -O)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.3" valueType="enumerated"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS.1331505903" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS.933312884" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS.645817356" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS"/>
@@ -885,7 +885,6 @@
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/reliance_edge/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/include/ex2_os}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services}"/>
-									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/ex2_demo_software}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/libcsp/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/include}"/>
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
@@ -906,8 +905,8 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.1111705335" name="Wrap diagnostic messages (--diag_wrap)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WRAP.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER.528285193" name="Emit diagnostic identifier numbers (--display_error_number, -pden)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DISPLAY_ERROR_NUMBER" value="true" valueType="boolean"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.2105519956" name="C Dialect" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.C99" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.1620286787" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.2" valueType="enumerated"/>
-								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EMIT_WARNINGS_AS_ERRORS.931769931" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EMIT_WARNINGS_AS_ERRORS" value="true" valueType="boolean"/>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.1620286787" name="Optimization level (--opt_level, -O)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.3" valueType="enumerated"/>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EMIT_WARNINGS_AS_ERRORS.931769931" name="Treat warnings as errors (--emit_warnings_as_errors, -pdew)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EMIT_WARNINGS_AS_ERRORS" value="true" valueType="boolean"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS.1553192376" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS.721209601" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS.1142206802" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS"/>

--- a/ex2_hal/charon/equipment_handler/include/NMEAParser.h
+++ b/ex2_hal/charon/equipment_handler/include/NMEAParser.h
@@ -48,9 +48,9 @@ enum {
 #define NMEA_QUEUE_ITEM_SIZE NMEASENTENCE_MAXLENGTH
 #define NMEA_QUEUE_MAX_LEN 2
 
-QueueHandle_t NMEA_queue;
+extern QueueHandle_t NMEA_queue;
 
-SemaphoreHandle_t NMEA_mutex;
+extern SemaphoreHandle_t NMEA_mutex;
 
 bool init_NMEA();
 

--- a/ex2_hal/charon/equipment_handler/source/NMEAParser.c
+++ b/ex2_hal/charon/equipment_handler/source/NMEAParser.c
@@ -20,6 +20,10 @@ static bool NMEAParser_decode_sentence();
 static char _sentence[NMEASENTENCE_MAXLENGTH];
 static int _char_offset;
 
+QueueHandle_t NMEA_queue;
+
+SemaphoreHandle_t NMEA_mutex;
+
 const static GPGGA_s GPGGA_invalid = {._time = GPS_INVALID_TIME,
                                       ._latitude_lower = GPS_INVALID_ANGLE,
                                       ._latitude_upper = GPS_INVALID_ANGLE,

--- a/ex2_hal/charon/equipment_handler/source/skytraq_binary.c
+++ b/ex2_hal/charon/equipment_handler/source/skytraq_binary.c
@@ -29,7 +29,7 @@
 
 enum current_sentence { none, binary, nmea } line_type;
 
-SemaphoreHandle_t tx_semphr;
+static SemaphoreHandle_t tx_semphr;
 static SemaphoreHandle_t uart_mutex;
 
 #define BUFSIZE 100

--- a/ex2_hal/charon/hardware_interface/test/charon_binary_test.c
+++ b/ex2_hal/charon/hardware_interface/test/charon_binary_test.c
@@ -32,7 +32,7 @@ bool charon_binary_test(void) {
         channel_to_reset = (Power_Channel)i;
     }
 
-    int temperatures[8] = {0};
+    int8_t temperatures[8] = {0};
     uint8_t threshold = 90;
     uint8_t max_measured_temp = 0;
     printf("Raise temperature of one sensor over 40 deg C to exit loop.\n");

--- a/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
+++ b/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
@@ -23,6 +23,7 @@
 #include "HL_sci.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "system.h"
 #include <stdint.h>
 

--- a/ex2_hal/dfgm/hardware_interface/source/dfgm.c
+++ b/ex2_hal/dfgm/hardware_interface/source/dfgm.c
@@ -20,6 +20,7 @@
 #include "dfgm.h"
 
 #include <FreeRTOS.h>
+#include <string.h>
 #include <csp/csp_endian.h>
 #include <os_queue.h>
 #include <stdint.h>
@@ -81,8 +82,8 @@ DFGM_return HAL_DFGM_stop() {
  */
 DFGM_return HAL_DFGM_get_HK(DFGM_Housekeeping *DFGM_hk) {
     DFGM_return status;
-    dfgm_housekeeping hk;
 #ifndef DFGM_IS_STUBBED
+    dfgm_housekeeping hk;
     status = DFGM_get_HK(&hk);
     DFGM_hk->coreVoltage = hk.coreVoltage;
     DFGM_hk->sensorTemp = hk.sensorTemp;

--- a/ex2_hal/eps/hardware_interface/source/eps.c
+++ b/ex2_hal/eps/hardware_interface/source/eps.c
@@ -24,6 +24,7 @@
  */
 
 #include <FreeRTOS.h>
+#include <string.h>
 #include <csp/csp.h>
 #include <csp/csp_endian.h>
 #include <main/system.h>
@@ -306,8 +307,6 @@ static inline void prv_set_startup_telemetry(eps_startup_telemetry_t telem_start
 }
 
 void prv_startup_telemetry_letoh(eps_startup_telemetry_t *telem_startup_buf) {
-    uint8_t i;
-
     telem_startup_buf->timestamp = csp_letohd(telem_startup_buf->timestamp);
     telem_startup_buf->last_reset_reason_reg = csp_letoh32(telem_startup_buf->last_reset_reason_reg);
     telem_startup_buf->bootCnt = csp_letoh32(telem_startup_buf->bootCnt);

--- a/ex2_hal/eps/hardware_interface/source/mocks/mock_eps.c
+++ b/ex2_hal/eps/hardware_interface/source/mocks/mock_eps.c
@@ -5,6 +5,7 @@
  *      Author: Andrew
  */
 #include <FreeRTOS.h>
+#include <string.h>
 #include <csp/csp.h>
 #include <csp/csp_endian.h>
 #include <os_task.h>
@@ -68,8 +69,8 @@ static SAT_returnState prv_fill_dummy_data(csp_packet_t *packet) {
             .curBattOut = 10,
             .curOutput = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
             .AOcurOutput = {1, 2},
-            .OutputConverterVoltage = {1, 2, 3, 4},
-            .outputConverterState = {1, 2, 3, 4},
+            .OutputConverterVoltage = {1, 2, 3, 4, 5, 6, 7, 8},
+            .outputConverterState = 10,
             .outputStatus = 10,
             .outputFaultStatus = 10,
             .outputOnDelta = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},


### PR DESCRIPTION
## [Clickup Task](app.clickup.com)(if applicable)

## Description of changes

There were a couple of link errors that needed to be fixed, but ex2_obc_software now compiles and runs at -O3. We should of course test it more to make sure nothing got optimized away

## Testing done

Built with -O3 and ran on devel card.

## Merge checklist
- [ ] Docker image or CCS Project builds with the changes
- [ ] Docker image or CCS Project runs with the changes
- [ ] Can send commands from a mocked ground station/relevant changes tested
- [ ] Changes have been reviewed
