### PR TITLE
Disable the version.sh external builder

### DIFF
--- a/.externalToolBuilders/Version_Builder.launch
+++ b/.externalToolBuilders/Version_Builder.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType">
     <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+    <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/ex2_obc_software/version.sh}"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
     <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>


### PR DESCRIPTION
## [Clickup Task](app.clickup.com)(if applicable)

## Description of changes

This should be the commits from the PR https://github.com/AlbertaSat/ex2_obc_software/pull/125, minus the step to run the version script as part of the build.
The PR was reverted here https://github.com/AlbertaSat/ex2_obc_software/pull/129

## Testing done
Confirmed that CCS no longer tries to build version.h
 
## Merge checklist
- [ ] Docker image or CCS Project builds with the changes
- [ ] Docker image or CCS Project runs with the changes
- [ ] Can send commands from a mocked ground station/relevant changes tested
- [ ] Changes have been reviewed
