### PR TITLE
fix git tag workflow

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: tag the default repository
-      run: ./.github/scripts/tag.sh ${{ github.ref_name }}
+      run: ./.github/scripts/tag.sh $BRANCH_NAME
       shell: bash


### PR DESCRIPTION
I was using ${{ github.ref_name }} to get the branch name, but it appears to always resolve to "master".

Try $BRANCH_NAMAE to see if that works better