### PR TITLE
Pausing code no longer screws up dfgm packet receipt

### DIFF
--- a/ex2_hal/dfgm/equipment_handler/include/dfgm_handler.h
+++ b/ex2_hal/dfgm/equipment_handler/include/dfgm_handler.h
@@ -70,9 +70,9 @@ typedef enum {
 #define HK_OFFSET_11 0
 
 // Misc. macros
-#define MIN_RUNTIME 1 // in seconds
-#define TIME_THRESHOLD 180 // in seconds
-#define QUEUE_DEPTH 1500
+#define DFGM_MIN_RUNTIME 1 // in seconds
+#define DFGM_TIME_THRESHOLD 20 // in seconds
+#define DFGM_QUEUE_DEPTH 1248
 
 typedef struct __attribute__((packed)) {
     uint32_t x; // [xdac, xadc]


### PR DESCRIPTION
The queue still overflows if you pause, but now the queue will resynchronize at the start of a new dfgm packet packet by using the fact that the dfgm sends a packet every second.