### PR TITLE
github workflow: use the first 10 digits of the hash

### DIFF
--- a/.github/scripts/tag.sh
+++ b/.github/scripts/tag.sh
@@ -1,6 +1,10 @@
-# arg should be a branch name
-ref=$1
+# arg1 is the author's name, arg2 is the git hash
+author=$1
+hash=$2
+
 tagdate=`date +"%Y-%m-%d"`
-git tag $tagdate.$ref
-git push origin $tagdate.$ref
+tagstr=$tagdate.$author.${hash:0:10}
+
+git tag $tagstr
+git push origin $tagstr
 

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: tag the default repository
-        run: ./.github/scripts/tag.sh "$GITHUB_ACTOR.$GITHUB_SHA"
+        run: ./.github/scripts/tag.sh "$GITHUB_ACTOR" "$GITHUB_SHA"
         shell: bash


### PR DESCRIPTION
The entire hash was pretty long and unnecessary
