### PR TITLE
configure_repo.sh: add a call to version.sh

### DIFF
--- a/configure_repo.sh
+++ b/configure_repo.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+echo "create version.sh"
+./version.sh
 echo "Initializing submodules"
 git submodule init 
 echo "Updating submodules"


### PR DESCRIPTION
I tried to have CCS automatically call version.sh but for some reason it didn't work on Windoze. We've been running it manually for a while but that is turning out to be a stumbling block for newcomers. Time to add a call to version.sh to configure_repo.sh 
