### PR TITLE
Use a config file instead of predefining symbols

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -103,22 +103,7 @@
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_sdr/include/pdu}"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE.1282553538" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="SBAND_COMMERCIAL_FREQUENCY"/>
-									<listOptionValue builtIn="false" value="IS_EXALTA2"/>
-									<listOptionValue builtIn="false" value="DFGM_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="CSP_FREERTOS"/>
-									<listOptionValue builtIn="false" value="OS_FREERTOS"/>
-									<listOptionValue builtIn="false" value="SBAND_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="CHARON_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="SYSTEM_APP_ID=_OBC_APP_ID_"/>
-									<listOptionValue builtIn="false" value="EPS_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="ADCS_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="PAYLOAD_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="UHF_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="WATCHDOG_IS_STUBBED"/>
-									<listOptionValue builtIn="false" value="ATHENA_IS_STUBBED"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE.1282553538" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEFINE" valueType="definedSymbols"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEBUGGING_MODEL.517860824" name="Debugging model" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEBUGGING_MODEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DEBUGGING_MODEL.SYMDEBUG__DWARF" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WARNING.1029290207" name="Treat diagnostic &lt;id&gt; as warning (--diag_warning, -pdsw)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.DIAG_WARNING" valueType="stringList">
 									<listOptionValue builtIn="false" value="225"/>
@@ -128,6 +113,9 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.1597551648" name="C Dialect" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.C_DIALECT.C99" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.284321430" name="Optimization level (--opt_level, -O)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.OPT_LEVEL.off" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EXCEPTIONS.224039873" name="Enable C++ exception handling (--exceptions)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.EXCEPTIONS" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.PREINCLUDE.1646675623" name="Specify a preinclude file (--preinclude)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.PREINCLUDE" valueType="includeFiles">
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main/config.h}"/>
+								</option>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS.514290555" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS.90709160" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS.1990194205" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compiler.inputType__ASM_SRCS"/>
@@ -1550,6 +1538,8 @@
 	<storageModule moduleId="scannerConfiguration"/>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Devel"/>
+		<configuration configurationName="ex2_project"/>
 		<configuration configurationName="Debug">
 			<resource resourceType="PROJECT" workspacePath="/can"/>
 		</configuration>
@@ -1558,4 +1548,5 @@
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="scannerConfiguration"/>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>

--- a/ex2_hal/adcs/equipment_handler/src/adcs_handler.c
+++ b/ex2_hal/adcs/equipment_handler/src/adcs_handler.c
@@ -1062,7 +1062,8 @@ ADCS_returnState ADCS_set_sram_scrub_size(uint16_t size) {
 ADCS_returnState ADCS_set_UnixTime_save_config(uint8_t when, uint8_t period) {
     uint8_t command[3];
 
-    if((when != 0) && (when != 1) && (when != 2) && (when != 4)) return ADCS_INVALID_PARAMETERS;
+    if ((when != 0) && (when != 1) && (when != 2) && (when != 4))
+        return ADCS_INVALID_PARAMETERS;
     command[0] = SET_UNIX_TIME_SAVE_ID;
     command[1] = when;
     command[2] = period; // [s]
@@ -1310,11 +1311,10 @@ ADCS_returnState ADCS_get_bootloader_state(uint16_t *uptime, uint8_t *flags_arr)
     state = adcs_telemetry(GET_BOOTLOADER_STATE_ID, telemetry, 6);
     *uptime = (telemetry[1] << 8) + telemetry[0];
 
-
     for (int i = 0; i < 8; i++) {
         *(flags_arr + i) = (telemetry[2] >> i) & 1; // Second telemetry byte contains 8 flags
     }
-    for(int i = 0; i < 4; i++){
+    for (int i = 0; i < 4; i++) {
         *(flags_arr + 8 + i) = (telemetry[3] >> i) & 1; // Third telemetry byte contains 4 flags
     }
     return state;
@@ -1375,7 +1375,7 @@ ADCS_returnState ADCS_copy_internal_flash_progress(bool *busy, bool *err) {
  * 		Success of function defined in adcs_types.h
  */
 ADCS_returnState ADCS_deploy_magnetometer_boom(uint8_t actuation_timeout) {
-#ifndef ADCS_MAG_FLIGHT_CONFIG // Safeguard against unintended mag deployment
+#if ADCS_MAG_FLIGHT_CONFIG == 0 // Safeguard against unintended mag deployment
     return ADCS_INVALID_PARAMETERS;
 #else
     uint8_t command[2];
@@ -1930,7 +1930,7 @@ ADCS_returnState ADCS_get_actuator(adcs_actuator *commands) {
     ADCS_returnState state;
     state = adcs_telemetry(ACTUATOR_ID, telemetry, 12);
     get_xyz(&commands->magnetorquer, &telemetry[0], 10); // [s]
-    get_xyz(&commands->wheel_speed, &telemetry[6], 1);    // [rpm]
+    get_xyz(&commands->wheel_speed, &telemetry[6], 1);   // [rpm]
     return state;
 }
 
@@ -2337,11 +2337,9 @@ ADCS_returnState ADCS_set_track_controller(xyz target) {
     command[0] = SET_TRACK_CTRLER_TARGET_REF_ID;
     uint32_t temp_32[3];
     memcpy(temp_32, &target, 12);
-    for(int i = 0; i < 3; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 3; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(&command[1], temp_32, 12);
     return adcs_telecommand(command, 13);
@@ -2361,11 +2359,9 @@ ADCS_returnState ADCS_get_track_controller(xyz *target) {
     state = adcs_telemetry(GET_TRACK_CTRLER_TARGET_REF_ID, telemetry, 12);
     uint32_t temp_32[3];
     memcpy(temp_32, &telemetry[0], 12);
-    for(int i = 0; i < 3; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 3; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(target, temp_32, 12);
     return state;
@@ -3065,10 +3061,10 @@ ADCS_returnState ADCS_set_mtm_config(mtm_config params, uint8_t mtm) {
     command[12] = (raw_val_offset.z & 0xFF00) >> 8;
 
     int16_t temp16;
-    for(int i = 0; i < 9; i++){ // Swap endianness of 2-byte ints
+    for (int i = 0; i < 9; i++) { // Swap endianness of 2-byte ints
         temp16 = (int16_t)params.sensitivity_mat[i] * coef;
-        command[13 + 2*i] = temp16 & 0xFF;
-        command[13 + 2*i + 1] = (temp16 & 0xFF00) >> 8;
+        command[13 + 2 * i] = temp16 & 0xFF;
+        command[13 + 2 * i + 1] = (temp16 & 0xFF00) >> 8;
     }
     return adcs_telecommand(command, 31);
 }
@@ -3085,11 +3081,9 @@ ADCS_returnState ADCS_set_detumble_config(detumble_config *config) {
     command[0] = SET_DETUMBLE_PARAM_ID;
     uint32_t temp_32[4];
     memcpy(temp_32, config, 16);
-    for(int i = 0; i < 4; i++){ // Swap endianness
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 4; i++) { // Swap endianness
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(&command[1], temp_32, 8);
     int16_t raw_spin_rate = config->spin_rate * 1000;
@@ -3111,11 +3105,9 @@ ADCS_returnState ADCS_set_ywheel_config(ywheel_ctrl_config params) {
     command[0] = SET_YWHEEL_CTRL_PARAM_ID;
     uint32_t temp_32[5];
     memcpy(temp_32, &params, 20);
-    for(int i = 0; i < 5; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 5; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(&command[1], temp_32, 20);
     return adcs_telecommand(command, 21);
@@ -3133,11 +3125,9 @@ ADCS_returnState ADCS_set_rwheel_config(rwheel_ctrl_config params) {
     command[0] = SET_RWHEEL_CTRL_PARAM_ID;
     uint32_t temp_32[3];
     memcpy(temp_32, &params, 12);
-    for(int i = 0; i < 3; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 3; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(&command[1], temp_32, 12);
     command[13] = (params.auto_transit << 7) | (params.sun_point_facet & 0x7F);
@@ -3156,11 +3146,9 @@ ADCS_returnState ADCS_set_tracking_config(track_ctrl_config params) {
     command[0] = SET_TRACK_CTRL_ID;
     uint32_t temp_32[3];
     memcpy(temp_32, &params, 12);
-    for(int i = 0; i < 3; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 3; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     memcpy(&command[1], temp_32, 12);
     command[13] = params.target_facet;
@@ -3210,11 +3198,9 @@ ADCS_returnState ADCS_set_estimation_config(estimation_config config) {
     uint8_t command[32];
     uint32_t temp_32[7];
     memcpy(temp_32, &config, 28);
-    for(int i = 0; i < 7; i++){
-        temp_32[i] = (temp_32[i] & 0x000000FF) << 24
-                | (temp_32[i] & 0x0000FF00) << 8
-                | (temp_32[i] & 0x00FF0000) >> 8
-                | (temp_32[i] & 0xFF000000) >> 24;
+    for (int i = 0; i < 7; i++) {
+        temp_32[i] = (temp_32[i] & 0x000000FF) << 24 | (temp_32[i] & 0x0000FF00) << 8 |
+                     (temp_32[i] & 0x00FF0000) >> 8 | (temp_32[i] & 0xFF000000) >> 24;
     }
     command[0] = SET_ESTIMATE_PARAM;
     memcpy(&command[1], &temp_32, 28);

--- a/ex2_hal/adcs/hardware_interface/source/adcs.c
+++ b/ex2_hal/adcs/hardware_interface/source/adcs.c
@@ -20,7 +20,7 @@
 #include "adcs.h"
 
 ADCS_returnState HAL_ADCS_download_file_list_to_OBC(void) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_file_list();
@@ -28,7 +28,7 @@ ADCS_returnState HAL_ADCS_download_file_list_to_OBC(void) {
 }
 
 ADCS_returnState HAL_ADCS_download_file_to_OBC(adcs_file_download_id *id) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     // Spawn high-priority file download task
@@ -44,7 +44,7 @@ ADCS_returnState HAL_ADCS_download_file_to_OBC(adcs_file_download_id *id) {
 }
 
 ADCS_returnState HAL_ADCS_reset() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_reset();
@@ -52,7 +52,7 @@ ADCS_returnState HAL_ADCS_reset() {
 }
 
 ADCS_returnState HAL_ADCS_reset_log_pointer() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_reset_log_pointer();
@@ -60,7 +60,7 @@ ADCS_returnState HAL_ADCS_reset_log_pointer() {
 }
 
 ADCS_returnState HAL_ADCS_advance_log_pointer() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_advance_log_pointer();
@@ -68,7 +68,7 @@ ADCS_returnState HAL_ADCS_advance_log_pointer() {
 }
 
 ADCS_returnState HAL_ADCS_reset_boot_registers() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_reset_boot_registers();
@@ -76,7 +76,7 @@ ADCS_returnState HAL_ADCS_reset_boot_registers() {
 }
 
 ADCS_returnState HAL_ADCS_format_sd_card() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_format_sd_card();
@@ -84,7 +84,7 @@ ADCS_returnState HAL_ADCS_format_sd_card() {
 }
 
 ADCS_returnState HAL_ADCS_erase_file(uint8_t file_type, uint8_t file_counter, bool erase_all) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_erase_file(file_type, file_counter, erase_all);
@@ -93,7 +93,7 @@ ADCS_returnState HAL_ADCS_erase_file(uint8_t file_type, uint8_t file_counter, bo
 
 ADCS_returnState HAL_ADCS_load_file_download_block(uint8_t file_type, uint8_t counter, uint32_t offset,
                                                    uint16_t block_length) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_load_file_download_block(file_type, counter, offset, block_length);
@@ -101,7 +101,7 @@ ADCS_returnState HAL_ADCS_load_file_download_block(uint8_t file_type, uint8_t co
 }
 
 ADCS_returnState HAL_ADCS_advance_file_list_read_pointer() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_advance_file_list_read_pointer();
@@ -109,7 +109,7 @@ ADCS_returnState HAL_ADCS_advance_file_list_read_pointer() {
 }
 
 ADCS_returnState HAL_ADCS_initiate_file_upload(uint8_t file_dest, uint8_t block_size) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_initiate_file_upload(file_dest, block_size);
@@ -117,7 +117,7 @@ ADCS_returnState HAL_ADCS_initiate_file_upload(uint8_t file_dest, uint8_t block_
 }
 
 ADCS_returnState HAL_ADCS_file_upload_packet(uint16_t packet_number, char *file_bytes) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_file_upload_packet(packet_number, file_bytes);
@@ -125,7 +125,7 @@ ADCS_returnState HAL_ADCS_file_upload_packet(uint16_t packet_number, char *file_
 }
 
 ADCS_returnState HAL_ADCS_finalize_upload_block(uint8_t file_dest, uint32_t offset, uint16_t block_length) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_finalize_upload_block(file_dest, offset, block_length);
@@ -133,7 +133,7 @@ ADCS_returnState HAL_ADCS_finalize_upload_block(uint8_t file_dest, uint32_t offs
 }
 
 ADCS_returnState HAL_ADCS_reset_upload_block() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_reset_upload_block();
@@ -141,7 +141,7 @@ ADCS_returnState HAL_ADCS_reset_upload_block() {
 }
 
 ADCS_returnState HAL_ADCS_reset_file_list_read_pointer() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_reset_file_list_read_pointer();
@@ -149,7 +149,7 @@ ADCS_returnState HAL_ADCS_reset_file_list_read_pointer() {
 }
 
 ADCS_returnState HAL_ADCS_initiate_download_burst(uint8_t msg_length, bool ignore_hole_map) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_initiate_download_burst(msg_length, ignore_hole_map);
@@ -157,7 +157,7 @@ ADCS_returnState HAL_ADCS_initiate_download_burst(uint8_t msg_length, bool ignor
 }
 
 ADCS_returnState HAL_ADCS_get_node_identification(ADCS_node_identification *node_id) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_node_identification(&node_id->node_type, &node_id->interface_ver, &node_id->major_firm_ver,
@@ -166,7 +166,7 @@ ADCS_returnState HAL_ADCS_get_node_identification(ADCS_node_identification *node
 }
 
 ADCS_returnState HAL_ADCS_get_boot_program_stat(ADCS_boot_program_stat *boot_program_stat) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_boot_program_stat(&boot_program_stat->mcu_reset_cause, &boot_program_stat->boot_cause,
@@ -177,7 +177,7 @@ ADCS_returnState HAL_ADCS_get_boot_program_stat(ADCS_boot_program_stat *boot_pro
 }
 
 ADCS_returnState HAL_ADCS_get_boot_index(ADCS_boot_index *boot_index) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_boot_index(&boot_index->program_idx, &boot_index->boot_stat);
@@ -185,7 +185,7 @@ ADCS_returnState HAL_ADCS_get_boot_index(ADCS_boot_index *boot_index) {
 }
 
 ADCS_returnState HAL_ADCS_get_last_logged_event(ADCS_last_logged_event *last_logged_event) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_last_logged_event(&last_logged_event->time, &last_logged_event->event_id,
@@ -194,7 +194,7 @@ ADCS_returnState HAL_ADCS_get_last_logged_event(ADCS_last_logged_event *last_log
 }
 
 ADCS_returnState HAL_ADCS_get_SD_format_progress(bool *format_busy, bool *erase_all_busy) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_SD_format_progress(format_busy, erase_all_busy);
@@ -202,7 +202,7 @@ ADCS_returnState HAL_ADCS_get_SD_format_progress(bool *format_busy, bool *erase_
 }
 
 ADCS_returnState HAL_ADCS_get_TC_ack(ADCS_TC_ack *TC_ack) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_TC_ack(&TC_ack->last_tc_id, &TC_ack->tc_processed, &TC_ack->tc_err_stat, &TC_ack->tc_err_idx);
@@ -210,7 +210,7 @@ ADCS_returnState HAL_ADCS_get_TC_ack(ADCS_TC_ack *TC_ack) {
 }
 
 ADCS_returnState HAL_ADCS_get_file_download_buffer(uint16_t *packet_count, uint8_t file[20]) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_file_download_buffer(packet_count, file);
@@ -218,7 +218,7 @@ ADCS_returnState HAL_ADCS_get_file_download_buffer(uint16_t *packet_count, uint8
 }
 
 ADCS_returnState HAL_ADCS_get_file_download_block_stat(ADCS_file_download_block_stat *file_download_block_stat) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_file_download_block_stat(
@@ -228,7 +228,7 @@ ADCS_returnState HAL_ADCS_get_file_download_block_stat(ADCS_file_download_block_
 }
 
 ADCS_returnState HAL_ADCS_get_file_info(ADCS_file_info *file_info) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_file_info(file_info);
@@ -236,7 +236,7 @@ ADCS_returnState HAL_ADCS_get_file_info(ADCS_file_info *file_info) {
 }
 
 ADCS_returnState HAL_ADCS_get_init_upload_stat(bool *busy) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_init_upload_stat(busy);
@@ -244,7 +244,7 @@ ADCS_returnState HAL_ADCS_get_init_upload_stat(bool *busy) {
 }
 
 ADCS_returnState HAL_ADCS_get_finalize_upload_stat(bool *busy, bool *err) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_finalize_upload_stat(busy, err);
@@ -252,7 +252,7 @@ ADCS_returnState HAL_ADCS_get_finalize_upload_stat(bool *busy, bool *err) {
 }
 
 ADCS_returnState HAL_ADCS_get_upload_crc16_checksum(uint16_t *checksum) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_upload_crc16_checksum(checksum);
@@ -260,7 +260,7 @@ ADCS_returnState HAL_ADCS_get_upload_crc16_checksum(uint16_t *checksum) {
 }
 
 ADCS_returnState HAL_ADCS_get_SRAM_latchup_count(ADCS_SRAM_latchup_count *SRAM_latchup_count) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_SRAM_latchup_count(&SRAM_latchup_count->sram1, &SRAM_latchup_count->sram2);
@@ -268,7 +268,7 @@ ADCS_returnState HAL_ADCS_get_SRAM_latchup_count(ADCS_SRAM_latchup_count *SRAM_l
 }
 
 ADCS_returnState HAL_ADCS_get_EDAC_err_count(ADCS_EDAC_err_count *EDAC_err_count) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_EDAC_err_count(&EDAC_err_count->single_sram, &EDAC_err_count->double_sram,
@@ -277,7 +277,7 @@ ADCS_returnState HAL_ADCS_get_EDAC_err_count(ADCS_EDAC_err_count *EDAC_err_count
 }
 
 ADCS_returnState HAL_ADCS_get_comms_stat(uint16_t *comm_status) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     ADCS_returnState return_state;
@@ -295,7 +295,7 @@ ADCS_returnState HAL_ADCS_get_comms_stat(uint16_t *comm_status) {
 }
 
 ADCS_returnState HAL_ADCS_set_cache_en_state(bool en_state) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_cache_en_state(en_state);
@@ -303,7 +303,7 @@ ADCS_returnState HAL_ADCS_set_cache_en_state(bool en_state) {
 }
 
 ADCS_returnState HAL_ADCS_set_sram_scrub_size(uint16_t size) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_sram_scrub_size(size);
@@ -311,7 +311,7 @@ ADCS_returnState HAL_ADCS_set_sram_scrub_size(uint16_t size) {
 }
 
 ADCS_returnState HAL_ADCS_set_UnixTime_save_config(uint8_t when, uint8_t period) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_UnixTime_save_config(when, period);
@@ -319,7 +319,7 @@ ADCS_returnState HAL_ADCS_set_UnixTime_save_config(uint8_t when, uint8_t period)
 }
 
 ADCS_returnState HAL_ADCS_set_hole_map(uint8_t *hole_map, uint8_t num) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_hole_map(hole_map, num);
@@ -327,7 +327,7 @@ ADCS_returnState HAL_ADCS_set_hole_map(uint8_t *hole_map, uint8_t num) {
 }
 
 ADCS_returnState HAL_ADCS_set_unix_t(uint32_t unix_t, uint16_t count_ms) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_unix_t(unix_t, count_ms);
@@ -335,7 +335,7 @@ ADCS_returnState HAL_ADCS_set_unix_t(uint32_t unix_t, uint16_t count_ms) {
 }
 
 ADCS_returnState HAL_ADCS_get_cache_en_state(bool *en_state) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_cache_en_state(en_state);
@@ -343,7 +343,7 @@ ADCS_returnState HAL_ADCS_get_cache_en_state(bool *en_state) {
 }
 
 ADCS_returnState HAL_ADCS_get_sram_scrub_size(uint16_t *size) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_sram_scrub_size(size);
@@ -351,7 +351,7 @@ ADCS_returnState HAL_ADCS_get_sram_scrub_size(uint16_t *size) {
 }
 
 ADCS_returnState HAL_ADCS_get_UnixTime_save_config(ADCS_Unixtime_save_config *Unixtime_save_config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_UnixTime_save_config(&Unixtime_save_config->when, &Unixtime_save_config->period);
@@ -359,7 +359,7 @@ ADCS_returnState HAL_ADCS_get_UnixTime_save_config(ADCS_Unixtime_save_config *Un
 }
 
 ADCS_returnState HAL_ADCS_get_hole_map(uint8_t *hole_map, uint8_t num) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_hole_map(hole_map, num);
@@ -367,7 +367,7 @@ ADCS_returnState HAL_ADCS_get_hole_map(uint8_t *hole_map, uint8_t num) {
 }
 
 ADCS_returnState HAL_ADCS_get_unix_t(ADCS_unix_t *A_unix_t) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_unix_t(&A_unix_t->unix_t, &A_unix_t->count_ms);
@@ -375,7 +375,7 @@ ADCS_returnState HAL_ADCS_get_unix_t(ADCS_unix_t *A_unix_t) {
 }
 
 ADCS_returnState HAL_ADCS_clear_err_flags() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_clear_err_flags();
@@ -383,7 +383,7 @@ ADCS_returnState HAL_ADCS_clear_err_flags() {
 }
 
 ADCS_returnState HAL_ADCS_set_boot_index(uint8_t index) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_boot_index(index);
@@ -391,7 +391,7 @@ ADCS_returnState HAL_ADCS_set_boot_index(uint8_t index) {
 }
 
 ADCS_returnState HAL_ADCS_run_selected_program() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_run_selected_program();
@@ -399,7 +399,7 @@ ADCS_returnState HAL_ADCS_run_selected_program() {
 }
 
 ADCS_returnState HAL_ADCS_read_program_info(uint8_t index) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_read_program_info(index);
@@ -407,7 +407,7 @@ ADCS_returnState HAL_ADCS_read_program_info(uint8_t index) {
 }
 
 ADCS_returnState HAL_ADCS_copy_program_internal_flash(uint8_t index, uint8_t overwrite_flag) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_copy_program_internal_flash(index, overwrite_flag);
@@ -415,7 +415,7 @@ ADCS_returnState HAL_ADCS_copy_program_internal_flash(uint8_t index, uint8_t ove
 }
 
 ADCS_returnState HAL_ADCS_get_bootloader_state(ADCS_bootloader_state *bootloader_state) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_bootloader_state(&bootloader_state->uptime, &bootloader_state->flags_arr[0]);
@@ -423,7 +423,7 @@ ADCS_returnState HAL_ADCS_get_bootloader_state(ADCS_bootloader_state *bootloader
 }
 
 ADCS_returnState HAL_ADCS_get_program_info(ADCS_program_info *program_info) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_program_info(&program_info->index, &program_info->busy, &program_info->file_size,
@@ -432,7 +432,7 @@ ADCS_returnState HAL_ADCS_get_program_info(ADCS_program_info *program_info) {
 }
 
 ADCS_returnState HAL_ADCS_copy_internal_flash_progress(bool *busy, bool *err) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return HAL_ADCS_copy_internal_flash_progress(busy, err);
@@ -440,7 +440,7 @@ ADCS_returnState HAL_ADCS_copy_internal_flash_progress(bool *busy, bool *err) {
 }
 
 ADCS_returnState HAL_ADCS_deploy_magnetometer_boom(uint8_t actuation_timeout) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_deploy_magnetometer_boom(actuation_timeout);
@@ -448,7 +448,7 @@ ADCS_returnState HAL_ADCS_deploy_magnetometer_boom(uint8_t actuation_timeout) {
 }
 
 ADCS_returnState HAL_ADCS_set_enabled_state(uint8_t state) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_enabled_state(state);
@@ -456,7 +456,7 @@ ADCS_returnState HAL_ADCS_set_enabled_state(uint8_t state) {
 }
 
 ADCS_returnState HAL_ADCS_clear_latched_errs(bool adcs_flag, bool hk_flag) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_clear_latched_errs(adcs_flag, hk_flag);
@@ -464,7 +464,7 @@ ADCS_returnState HAL_ADCS_clear_latched_errs(bool adcs_flag, bool hk_flag) {
 }
 
 ADCS_returnState HAL_ADCS_set_attitude_ctrl_mode(uint8_t ctrl_mode, uint16_t timeout) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_attitude_ctrl_mode(ctrl_mode, timeout);
@@ -472,7 +472,7 @@ ADCS_returnState HAL_ADCS_set_attitude_ctrl_mode(uint8_t ctrl_mode, uint16_t tim
 }
 
 ADCS_returnState HAL_ADCS_set_attitude_estimate_mode(uint8_t mode) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_attitude_estimate_mode(mode);
@@ -480,7 +480,7 @@ ADCS_returnState HAL_ADCS_set_attitude_estimate_mode(uint8_t mode) {
 }
 
 ADCS_returnState HAL_ADCS_trigger_adcs_loop() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_trigger_adcs_loop();
@@ -488,7 +488,7 @@ ADCS_returnState HAL_ADCS_trigger_adcs_loop() {
 }
 
 ADCS_returnState HAL_ADCS_trigger_adcs_loop_sim(sim_sensor_data sim_data) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_trigger_adcs_loop_sim(sim_data);
@@ -496,7 +496,7 @@ ADCS_returnState HAL_ADCS_trigger_adcs_loop_sim(sim_sensor_data sim_data) {
 }
 
 ADCS_returnState HAL_ADCS_set_ASGP4_rune_mode(uint8_t mode) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_ASGP4_rune_mode(mode);
@@ -504,7 +504,7 @@ ADCS_returnState HAL_ADCS_set_ASGP4_rune_mode(uint8_t mode) {
 }
 
 ADCS_returnState HAL_ADCS_trigger_ASGP4() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_trigger_ASGP4();
@@ -512,7 +512,7 @@ ADCS_returnState HAL_ADCS_trigger_ASGP4() {
 }
 
 ADCS_returnState HAL_ADCS_set_MTM_op_mode(uint8_t mode) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_MTM_op_mode(mode);
@@ -520,7 +520,7 @@ ADCS_returnState HAL_ADCS_set_MTM_op_mode(uint8_t mode) {
 }
 
 ADCS_returnState HAL_ADCS_cnv2jpg(uint8_t source, uint8_t QF, uint8_t white_balance) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_cnv2jpg(source, QF, white_balance);
@@ -528,7 +528,7 @@ ADCS_returnState HAL_ADCS_cnv2jpg(uint8_t source, uint8_t QF, uint8_t white_bala
 }
 
 ADCS_returnState HAL_ADCS_save_img(uint8_t camera, uint8_t img_size) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_save_img(camera, img_size);
@@ -536,7 +536,7 @@ ADCS_returnState HAL_ADCS_save_img(uint8_t camera, uint8_t img_size) {
 }
 
 ADCS_returnState HAL_ADCS_set_magnetorquer_output(xyz16 duty_cycle) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_magnetorquer_output(duty_cycle);
@@ -544,7 +544,7 @@ ADCS_returnState HAL_ADCS_set_magnetorquer_output(xyz16 duty_cycle) {
 }
 
 ADCS_returnState HAL_ADCS_set_wheel_speed(xyz16 speed) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_wheel_speed(speed);
@@ -552,7 +552,7 @@ ADCS_returnState HAL_ADCS_set_wheel_speed(xyz16 speed) {
 }
 
 ADCS_returnState HAL_ADCS_save_config() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_save_config();
@@ -560,7 +560,7 @@ ADCS_returnState HAL_ADCS_save_config() {
 }
 
 ADCS_returnState HAL_ADCS_save_orbit_params() {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_save_orbit_params();
@@ -568,7 +568,7 @@ ADCS_returnState HAL_ADCS_save_orbit_params() {
 }
 
 ADCS_returnState HAL_ADCS_get_current_state(adcs_state *data) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_current_state(data);
@@ -576,7 +576,7 @@ ADCS_returnState HAL_ADCS_get_current_state(adcs_state *data) {
 }
 
 ADCS_returnState HAL_ADCS_get_jpg_cnv_progress(ADCS_jpg_cnv_progress *jpg_cnv_progress) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_jpg_cnv_progress(&jpg_cnv_progress->percentage, &jpg_cnv_progress->result,
@@ -585,7 +585,7 @@ ADCS_returnState HAL_ADCS_get_jpg_cnv_progress(ADCS_jpg_cnv_progress *jpg_cnv_pr
 }
 
 ADCS_returnState HAL_ADCS_get_cubeACP_state(uint8_t *flags_arr) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_cubeACP_state(flags_arr);
@@ -593,7 +593,7 @@ ADCS_returnState HAL_ADCS_get_cubeACP_state(uint8_t *flags_arr) {
 }
 
 ADCS_returnState HAL_ADCS_get_execution_times(ADCS_execution_times *execution_times) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_execution_times(&execution_times->adcs_update, &execution_times->sensor_comms,
@@ -602,7 +602,7 @@ ADCS_returnState HAL_ADCS_get_execution_times(ADCS_execution_times *execution_ti
 }
 
 ADCS_returnState HAL_ADCS_get_ACP_loop_stat(ADCS_ACP_loop_stat *ACP_loop_stat) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_ACP_loop_stat(&ACP_loop_stat->time, &ACP_loop_stat->execution_point);
@@ -610,7 +610,7 @@ ADCS_returnState HAL_ADCS_get_ACP_loop_stat(ADCS_ACP_loop_stat *ACP_loop_stat) {
 }
 
 ADCS_returnState HAL_ADCS_get_sat_pos_LLH(LLH *target) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_sat_pos_LLH(target);
@@ -618,7 +618,7 @@ ADCS_returnState HAL_ADCS_get_sat_pos_LLH(LLH *target) {
 }
 
 ADCS_returnState HAL_ADCS_get_img_save_progress(ADCS_img_save_progress *img_save_progress) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_img_save_progress(&img_save_progress->percentage, &img_save_progress->status);
@@ -626,7 +626,7 @@ ADCS_returnState HAL_ADCS_get_img_save_progress(ADCS_img_save_progress *img_save
 }
 
 ADCS_returnState HAL_ADCS_get_measurements(adcs_measures *measurements) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_measurements(measurements);
@@ -634,7 +634,7 @@ ADCS_returnState HAL_ADCS_get_measurements(adcs_measures *measurements) {
 }
 
 ADCS_returnState HAL_ADCS_get_actuator(adcs_actuator *commands) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_actuator(commands);
@@ -642,7 +642,7 @@ ADCS_returnState HAL_ADCS_get_actuator(adcs_actuator *commands) {
 }
 
 ADCS_returnState HAL_ADCS_get_estimation(adcs_estimate *data) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_estimation(data);
@@ -650,7 +650,7 @@ ADCS_returnState HAL_ADCS_get_estimation(adcs_estimate *data) {
 }
 
 ADCS_returnState HAL_ADCS_get_ASGP4(bool *complete, uint8_t *err, adcs_asgp4 *asgp4) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_ASGP4(complete, err, asgp4);
@@ -658,7 +658,7 @@ ADCS_returnState HAL_ADCS_get_ASGP4(bool *complete, uint8_t *err, adcs_asgp4 *as
 }
 
 ADCS_returnState HAL_ADCS_get_raw_sensor(adcs_raw_sensor *measurements) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_raw_sensor(measurements);
@@ -666,7 +666,7 @@ ADCS_returnState HAL_ADCS_get_raw_sensor(adcs_raw_sensor *measurements) {
 }
 
 ADCS_returnState HAL_ADCS_get_raw_GPS(adcs_raw_gps *measurements) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_raw_GPS(measurements);
@@ -674,7 +674,7 @@ ADCS_returnState HAL_ADCS_get_raw_GPS(adcs_raw_gps *measurements) {
 }
 
 ADCS_returnState HAL_ADCS_get_star_tracker(adcs_star_track *measurements) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_star_tracker(measurements);
@@ -682,7 +682,7 @@ ADCS_returnState HAL_ADCS_get_star_tracker(adcs_star_track *measurements) {
 }
 
 ADCS_returnState HAL_ADCS_get_MTM2_measurements(xyz16 *Mag) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_MTM2_measurements(Mag);
@@ -690,7 +690,7 @@ ADCS_returnState HAL_ADCS_get_MTM2_measurements(xyz16 *Mag) {
 }
 
 ADCS_returnState HAL_ADCS_get_power_temp(adcs_pwr_temp *measurements) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_power_temp(measurements);
@@ -698,7 +698,7 @@ ADCS_returnState HAL_ADCS_get_power_temp(adcs_pwr_temp *measurements) {
 }
 
 ADCS_returnState HAL_ADCS_set_power_control(uint8_t *control) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_power_control(control);
@@ -706,7 +706,7 @@ ADCS_returnState HAL_ADCS_set_power_control(uint8_t *control) {
 }
 
 ADCS_returnState HAL_ADCS_get_power_control(uint8_t *control) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_power_control(control);
@@ -714,7 +714,7 @@ ADCS_returnState HAL_ADCS_get_power_control(uint8_t *control) {
 }
 
 ADCS_returnState HAL_ADCS_set_attitude_angle(xyz att_angle) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_attitude_angle(att_angle);
@@ -722,7 +722,7 @@ ADCS_returnState HAL_ADCS_set_attitude_angle(xyz att_angle) {
 }
 
 ADCS_returnState HAL_ADCS_get_attitude_angle(xyz *att_angle) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_attitude_angle(att_angle);
@@ -730,7 +730,7 @@ ADCS_returnState HAL_ADCS_get_attitude_angle(xyz *att_angle) {
 }
 
 ADCS_returnState HAL_ADCS_set_track_controller(xyz target) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_track_controller(target);
@@ -738,7 +738,7 @@ ADCS_returnState HAL_ADCS_set_track_controller(xyz target) {
 }
 
 ADCS_returnState HAL_ADCS_get_track_controller(xyz *target) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_track_controller(target);
@@ -746,7 +746,7 @@ ADCS_returnState HAL_ADCS_get_track_controller(xyz *target) {
 }
 
 ADCS_returnState HAL_ADCS_set_log_config(uint8_t *flags_arr, uint16_t period, uint8_t dest, uint8_t log) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_log_config(flags_arr, period, dest, log);
@@ -754,7 +754,7 @@ ADCS_returnState HAL_ADCS_set_log_config(uint8_t *flags_arr, uint16_t period, ui
 }
 
 ADCS_returnState HAL_ADCS_get_log_config(uint8_t *flags_arr, uint16_t *period, uint8_t *dest, uint8_t log) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_log_config(flags_arr, period, dest, log);
@@ -762,7 +762,7 @@ ADCS_returnState HAL_ADCS_get_log_config(uint8_t *flags_arr, uint16_t *period, u
 }
 
 ADCS_returnState HAL_ADCS_set_inertial_ref(xyz iner_ref) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_inertial_ref(iner_ref);
@@ -770,7 +770,7 @@ ADCS_returnState HAL_ADCS_set_inertial_ref(xyz iner_ref) {
 }
 
 ADCS_returnState HAL_ADCS_get_inertial_ref(xyz *iner_ref) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_inertial_ref(iner_ref);
@@ -778,7 +778,7 @@ ADCS_returnState HAL_ADCS_get_inertial_ref(xyz *iner_ref) {
 }
 
 ADCS_returnState HAL_ADCS_set_sgp4_orbit_params(adcs_sgp4 params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_sgp4_orbit_params(params);
@@ -786,7 +786,7 @@ ADCS_returnState HAL_ADCS_set_sgp4_orbit_params(adcs_sgp4 params) {
 }
 
 ADCS_returnState HAL_ADCS_get_sgp4_orbit_params(adcs_sgp4 *params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_sgp4_orbit_params(params);
@@ -794,7 +794,7 @@ ADCS_returnState HAL_ADCS_get_sgp4_orbit_params(adcs_sgp4 *params) {
 }
 
 ADCS_returnState HAL_ADCS_set_system_config(adcs_sysConfig config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_system_config(config);
@@ -802,7 +802,7 @@ ADCS_returnState HAL_ADCS_set_system_config(adcs_sysConfig config) {
 }
 
 ADCS_returnState HAL_ADCS_get_system_config(adcs_sysConfig *config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_system_config(config);
@@ -810,7 +810,7 @@ ADCS_returnState HAL_ADCS_get_system_config(adcs_sysConfig *config) {
 }
 
 ADCS_returnState HAL_ADCS_set_MTQ_config(xyzu8 params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_MTQ_config(params);
@@ -818,7 +818,7 @@ ADCS_returnState HAL_ADCS_set_MTQ_config(xyzu8 params) {
 }
 
 ADCS_returnState HAL_ADCS_set_RW_config(uint8_t *RW) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_RW_config(RW);
@@ -826,7 +826,7 @@ ADCS_returnState HAL_ADCS_set_RW_config(uint8_t *RW) {
 }
 
 ADCS_returnState HAL_ADCS_set_rate_gyro(rate_gyro_config params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_rate_gyro(params);
@@ -834,7 +834,7 @@ ADCS_returnState HAL_ADCS_set_rate_gyro(rate_gyro_config params) {
 }
 
 ADCS_returnState HAL_ADCS_set_css_config(css_config config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_css_config(config);
@@ -842,7 +842,7 @@ ADCS_returnState HAL_ADCS_set_css_config(css_config config) {
 }
 
 ADCS_returnState HAL_ADCS_set_star_track_config(cubestar_config config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_star_track_config(config);
@@ -850,7 +850,7 @@ ADCS_returnState HAL_ADCS_set_star_track_config(cubestar_config config) {
 }
 
 ADCS_returnState HAL_ADCS_set_cubesense_config(cubesense_config params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_cubesense_config(params);
@@ -858,7 +858,7 @@ ADCS_returnState HAL_ADCS_set_cubesense_config(cubesense_config params) {
 }
 
 ADCS_returnState HAL_ADCS_set_mtm_config(mtm_config params, uint8_t mtm) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_mtm_config(params, mtm);
@@ -866,7 +866,7 @@ ADCS_returnState HAL_ADCS_set_mtm_config(mtm_config params, uint8_t mtm) {
 }
 
 ADCS_returnState HAL_ADCS_set_detumble_config(detumble_config *config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_detumble_config(config);
@@ -874,7 +874,7 @@ ADCS_returnState HAL_ADCS_set_detumble_config(detumble_config *config) {
 }
 
 ADCS_returnState HAL_ADCS_set_ywheel_config(ywheel_ctrl_config params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_ywheel_config(params);
@@ -882,7 +882,7 @@ ADCS_returnState HAL_ADCS_set_ywheel_config(ywheel_ctrl_config params) {
 }
 
 ADCS_returnState HAL_ADCS_set_rwheel_config(rwheel_ctrl_config params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_rwheel_config(params);
@@ -890,7 +890,7 @@ ADCS_returnState HAL_ADCS_set_rwheel_config(rwheel_ctrl_config params) {
 }
 
 ADCS_returnState HAL_ADCS_set_tracking_config(track_ctrl_config params) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_tracking_config(params);
@@ -898,7 +898,7 @@ ADCS_returnState HAL_ADCS_set_tracking_config(track_ctrl_config params) {
 }
 
 ADCS_returnState HAL_ADCS_set_MoI_mat(moment_inertia_config cell) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_MoI_mat(cell);
@@ -906,7 +906,7 @@ ADCS_returnState HAL_ADCS_set_MoI_mat(moment_inertia_config cell) {
 }
 
 ADCS_returnState HAL_ADCS_set_estimation_config(estimation_config config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_estimation_config(config);
@@ -914,7 +914,7 @@ ADCS_returnState HAL_ADCS_set_estimation_config(estimation_config config) {
 }
 
 ADCS_returnState HAL_ADCS_set_usercoded_setting(usercoded_setting setting) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_usercoded_setting(setting);
@@ -922,7 +922,7 @@ ADCS_returnState HAL_ADCS_set_usercoded_setting(usercoded_setting setting) {
 }
 
 ADCS_returnState HAL_ADCS_set_asgp4_setting(aspg4_setting setting) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_set_asgp4_setting(setting);
@@ -930,7 +930,7 @@ ADCS_returnState HAL_ADCS_set_asgp4_setting(aspg4_setting setting) {
 }
 
 ADCS_returnState HAL_ADCS_get_full_config(adcs_config *config) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     return ADCS_get_full_config(config);
@@ -938,7 +938,7 @@ ADCS_returnState HAL_ADCS_get_full_config(adcs_config *config) {
 }
 
 ADCS_returnState HAL_ADCS_getHK(ADCS_HouseKeeping *adcs_hk) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return IS_STUBBED_A;
 #else
     ADCS_returnState temp;

--- a/ex2_hal/athena/equipment_handler/include/rtcmk.h
+++ b/ex2_hal/athena/equipment_handler/include/rtcmk.h
@@ -10,16 +10,13 @@
 
 #include <stdint.h>
 #include "ex2_time.h"
+#include "system.h"
 /*******************************************************************************
  *******************************   DEFINES   ***********************************
  ******************************************************************************/
 
 #define RTCMK_ADDR (0x32)
-#ifdef IS_ATHENA
-#define RTCMK_PORT i2cREG2
-#else
-#define RTCMK_PORT i2cREG1 // port used on dev board
-#endif
+#define RTCMK_PORT RTC_I2C
 
 #define RTCMK_SEC_SEC (0x7FUL << 0)
 #define _RTCMK_SEC_SEC_SHIFT 0

--- a/ex2_hal/athena/equipment_handler/source/board_io_tests.c
+++ b/ex2_hal/athena/equipment_handler/source/board_io_tests.c
@@ -27,22 +27,22 @@ void InitIO(void) {
     spiInit();
     gioInit();
 
-    //emif_SDRAMInit(); not using until SDRAM tested
-    hetInit(); //don't think this is necessary
+    // emif_SDRAMInit(); not using until SDRAM tested
+    hetInit(); // don't think this is necessary
 
     // The following sets the proper direction for all GPIO
     gioSetDirection(hetPORT2, 0xFFFFFFEA);
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
     gioSetDirection(hetPORT1, 0x9CFF6BEF);
 #else
     gioSetDirection(hetPORT1, 0x9CFF7BEF);
 #endif
-    //gioSetDirection(gioPORTA, 0xFFFFFF6F);
-    //gioSetDirection(gioPORTB, 0xFFFFFFFF);
+    // gioSetDirection(gioPORTA, 0xFFFFFF6F);
+    // gioSetDirection(gioPORTB, 0xFFFFFFFF);
 
     gioSetBit(hetPORT2, 12, 1); // solar panel power - enable
     gioSetBit(hetPORT1, 20, 1); // IRIS nCONFIG - disable
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
     gioSetBit(hetPORT2, 6, 1); // SD card - disable
 #else
     gioSetBit(hetPORT1, 12, 1); // SD card - disable

--- a/ex2_hal/athena/equipment_handler/source/housekeeping_athena.c
+++ b/ex2_hal/athena/equipment_handler/source/housekeeping_athena.c
@@ -34,7 +34,7 @@ const uint8_t software_version = 3;
  * 		0 for success. other for failure
  */
 int HAL_get_temp_all(long *temparray) {
-#ifdef ATHENA_IS_STUBBED
+#if ATHENA_IS_STUBBED == 1
     return 0;
 #else
     return gettemp_all(temparray);

--- a/ex2_hal/athena/equipment_handler/source/spi_io.c
+++ b/ex2_hal/athena/equipment_handler/source/spi_io.c
@@ -31,7 +31,7 @@ void SPI_Release(void) {
 
 inline void SPI_CS_Low(uint8_t bVolNum) {
     if (bVolNum == 0) {
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
         gioSetBit(gioPORTA, 3, 0); // CS LOW
         gioSetBit(hetPORT2, 6, 1); // CS HIGH
 #else
@@ -41,7 +41,7 @@ inline void SPI_CS_Low(uint8_t bVolNum) {
 #endif
     } else if (bVolNum == 1) {
 
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
         gioSetBit(hetPORT2, 6, 0); // CS LOW
         gioSetBit(gioPORTA, 3, 1); // CS HIGH
 #else
@@ -52,7 +52,7 @@ inline void SPI_CS_Low(uint8_t bVolNum) {
 }
 
 inline void SPI_CS_High(uint8_t bVolNum) {
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
     gioSetBit(gioPORTA, 3, 1); // CS HIGH
     gioSetBit(hetPORT2, 6, 1); // CS HIGH
 #else

--- a/ex2_hal/charon/equipment_handler/include/ads7128.h
+++ b/ex2_hal/charon/equipment_handler/include/ads7128.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 
 #define ADS7128_ADDR (0x11)
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
 #define ADS7128_PORT i2cREG1
 #else
 #define ADS7128_PORT i2cREG1 // port used on dev board

--- a/ex2_hal/charon/equipment_handler/include/pcal9538a.h
+++ b/ex2_hal/charon/equipment_handler/include/pcal9538a.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define PCAL9538A_ADDR (0x70)
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
 #define PCAL9538A_PORT i2cREG2
 #else
 #define PCAL9538A_PORT i2cREG1 // port used on dev board

--- a/ex2_hal/charon/hardware_interface/source/housekeeping_charon.c
+++ b/ex2_hal/charon/hardware_interface/source/housekeeping_charon.c
@@ -27,7 +27,7 @@ GPS_RETURNSTATE Charon_getHK(charon_housekeeping *hk) {
     }
 
     // Read GPS firmware CRC
-#ifdef IS_EXALTA2
+#if IS_EXALTA2 == 1
     return gps_skytraq_get_software_crc(&hk->crc);
 #endif
 }

--- a/ex2_hal/dfgm/hardware_interface/source/dfgm.c
+++ b/ex2_hal/dfgm/hardware_interface/source/dfgm.c
@@ -40,9 +40,9 @@
  */
 DFGM_return HAL_DFGM_run(int32_t givenRuntime) {
     DFGM_return status;
-#ifndef DFGM_IS_STUBBED
+#if DFGM_IS_STUBBED == 0
     // DFGM connected to OBC
-    int runtime = (int) givenRuntime;
+    int runtime = (int)givenRuntime;
     status = DFGM_startDataCollection(runtime);
 #else
     // DFGM not connected
@@ -62,7 +62,7 @@ DFGM_return HAL_DFGM_run(int32_t givenRuntime) {
  */
 DFGM_return HAL_DFGM_stop() {
     DFGM_return status;
-#ifndef DFGM_IS_STUBBED
+#if DFGM_IS_STUBBED == 0
     status = DFGM_stopDataCollection();
 #else
     status = IS_STUBBED_DFGM;
@@ -82,7 +82,7 @@ DFGM_return HAL_DFGM_stop() {
  */
 DFGM_return HAL_DFGM_get_HK(DFGM_Housekeeping *DFGM_hk) {
     DFGM_return status;
-#ifndef DFGM_IS_STUBBED
+#if DFGM_IS_STUBBED == 0
     dfgm_housekeeping hk;
     status = DFGM_get_HK(&hk);
     DFGM_hk->coreVoltage = hk.coreVoltage;

--- a/ex2_hal/hyperion_solar_panel/hardware_interface/source/hyperion.c
+++ b/ex2_hal/hyperion_solar_panel/hardware_interface/source/hyperion.c
@@ -423,7 +423,7 @@ void Hyperion_config3_getHK(Hyperion_HouseKeeping *hyperion_hk) {
     // NADIR Temp Adc
     hyperion_hk->Nadir_Temp_Adc = adc_get_tsense_temp(PANEL_SLAVE_ADDR_NADIR2U, ADC_VREF);
 
-#ifndef HYPERION_PANEL_2U_LIMITED
+#if HYPERION_PANEL_2U_LIMITED == 0
     // Port 2U TEMP 1 2
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_TEMP_1, &hyperion_hk->Port_Temp1);
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_TEMP_2, &hyperion_hk->Port_Temp2);
@@ -468,7 +468,7 @@ void Hyperion_config3_getHK(Hyperion_HouseKeeping *hyperion_hk) {
     // Nadir Pd 1
     hyperion_config_2_value(CONFIG_2_PANEL_NADIR, CONFIG_2_CHANNEL_PD_1, &hyperion_hk->Nadir_Pd1);
 
-#ifndef HYPERION_PANEL_2U_LIMITED
+#if HYPERION_PANEL_2U_LIMITED == 0
     // Port 2U Pd 1 2
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_PD_1, &hyperion_hk->Port_Pd1);
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_PD_2, &hyperion_hk->Port_Pd2);
@@ -495,7 +495,7 @@ void Hyperion_config3_getHK(Hyperion_HouseKeeping *hyperion_hk) {
     hyperion_config_3_value(CONFIG_3_PANEL_Z2U, CONFIG_3_CHANNEL_PD_2, &hyperion_hk->Zenith_Pd2);
     hyperion_hk->Zenith_Pd3 = HYPERION_2U_PD_PLACEHOLDER;
 
-#ifndef HYPERION_PANEL_2U_LIMITED
+#if HYPERION_PANEL_2U_LIMITED == 0
     // Port 2U Voltage
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_VOLT, &hyperion_hk->Port_Voltage);
 
@@ -512,7 +512,7 @@ void Hyperion_config3_getHK(Hyperion_HouseKeeping *hyperion_hk) {
     // Zenith 2U Voltage
     hyperion_config_3_value(CONFIG_3_PANEL_Z2U, CONFIG_3_CHANNEL_VOLT, &hyperion_hk->Zenith_Voltage);
 
-#ifndef HYPERION_PANEL_2U_LIMITED
+#if HYPERION_PANEL_2U_LIMITED == 0
     // Port 2U Current
     hyperion_config_3_value(CONFIG_3_PANEL_P2U, CONFIG_3_CHANNEL_CURR, &hyperion_hk->Port_Current);
 

--- a/ex2_hal/northern_spirit/hardware_interface/source/ns_payload.c
+++ b/ex2_hal/northern_spirit/hardware_interface/source/ns_payload.c
@@ -21,7 +21,7 @@
 #include "ns_payload.h"
 
 NS_return HAL_NS_upload_artwork(char *filename) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_upload_artwork(filename);
 #else
     return NS_IS_STUBBED;
@@ -29,7 +29,7 @@ NS_return HAL_NS_upload_artwork(char *filename) {
 }
 
 NS_return HAL_NS_capture_image() {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_capture_image();
 #else
     return NS_IS_STUBBED;
@@ -37,7 +37,7 @@ NS_return HAL_NS_capture_image() {
 }
 
 NS_return HAL_NS_confirm_downlink(uint8_t *conf) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_confirm_downlink(conf);
 #else
     return NS_IS_STUBBED;
@@ -45,7 +45,7 @@ NS_return HAL_NS_confirm_downlink(uint8_t *conf) {
 }
 
 NS_return HAL_NS_get_heartbeat(uint8_t *heartbeat) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_get_heartbeat(heartbeat);
 #else
     return NS_IS_STUBBED;
@@ -53,7 +53,7 @@ NS_return HAL_NS_get_heartbeat(uint8_t *heartbeat) {
 }
 
 NS_return HAL_NS_get_flag(char flag, bool *stat) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_get_flag(flag, stat);
 #else
     return NS_IS_STUBBED;
@@ -61,7 +61,7 @@ NS_return HAL_NS_get_flag(char flag, bool *stat) {
 }
 
 NS_return HAL_NS_get_filename(char subcode, char *filename) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_get_filename(subcode, filename);
 #else
     return NS_IS_STUBBED;
@@ -69,7 +69,7 @@ NS_return HAL_NS_get_filename(char subcode, char *filename) {
 }
 
 NS_return HAL_NS_get_telemetry(ns_telemetry *tlm) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_get_telemetry(tlm);
 #else
     return NS_IS_STUBBED;
@@ -77,7 +77,7 @@ NS_return HAL_NS_get_telemetry(ns_telemetry *tlm) {
 }
 
 NS_return HAL_NS_get_software_version(uint8_t *version) {
-#ifndef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 0
     return NS_get_software_version(version);
 #else
     return NS_IS_STUBBED;

--- a/ex2_hal/sband/hardware_interface/source/sband.c
+++ b/ex2_hal/sband/hardware_interface/source/sband.c
@@ -35,7 +35,7 @@ static Sband_Full_Status S_FS;
 
 STX_return HAL_S_getFreq(float *S_freq) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getFrequency(&S_config_reg.freq);
 #else
     status = IS_STUBBED_S;
@@ -46,7 +46,7 @@ STX_return HAL_S_getFreq(float *S_freq) {
 
 STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getControl(&S_config_reg.PA.status, &S_config_reg.PA.mode);
 #else
     status = IS_STUBBED_S;
@@ -57,9 +57,9 @@ STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA) {
 
 STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
-    status = STX_getEncoder(&S_config_reg.enc.bit_order, &S_config_reg.enc.scrambler, &S_config_reg.enc.filter, &S_config_reg.enc.modulation,
-                            &S_config_reg.enc.rate);
+#if SBAND_IS_STUBBED == 0
+    status = STX_getEncoder(&S_config_reg.enc.bit_order, &S_config_reg.enc.scrambler, &S_config_reg.enc.filter,
+                            &S_config_reg.enc.modulation, &S_config_reg.enc.rate);
 #else
     status = IS_STUBBED_S;
 #endif
@@ -69,7 +69,7 @@ STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc) {
 
 STX_return HAL_S_getPAPower(uint8_t *S_PA_Power) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getPaPower(&S_config_reg.PA_Power);
 #else
     status = IS_STUBBED_S;
@@ -80,7 +80,7 @@ STX_return HAL_S_getPAPower(uint8_t *S_PA_Power) {
 
 STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getFirmwareV(&S_FS.firmware.firmware);
 #else
     S_FS.firmware.firmware = 111;
@@ -92,7 +92,7 @@ STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV) {
 
 STX_return HAL_S_getStatus(Sband_Status *S_status) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getStatus(&S_FS.status.PWRGD, &S_FS.status.TXL);
 #else
     S_FS.status.PWRGD = 1;
@@ -105,7 +105,7 @@ STX_return HAL_S_getStatus(Sband_Status *S_status) {
 
 STX_return HAL_S_getTR(Sband_TR *S_transmit) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getTR(&S_FS.transmit.transmit);
 #else
     S_FS.transmit.transmit = 1;
@@ -117,7 +117,7 @@ STX_return HAL_S_getTR(Sband_TR *S_transmit) {
 
 STX_return HAL_S_getHK(Sband_Housekeeping *S_hk) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getHK(&S_FS.HK);
 #else
     S_FS.HK.Output_Power = 26;
@@ -151,7 +151,7 @@ STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk) {
 STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer) {
     STX_return status;
     /* Although there is no writing data, we can call a function like them*/
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getBuffer(quantity, &S_FS.buffer.pointer[quantity]);
 #else
     S_FS.buffer.pointer[quantity] = quantity;
@@ -162,7 +162,7 @@ STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer) {
 }
 
 STX_return HAL_S_softResetFPGA(void) {
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_softResetFPGA();
@@ -171,7 +171,7 @@ STX_return HAL_S_softResetFPGA(void) {
 
 STX_return HAL_S_setFreq(float S_freq_new) {
     S_config_reg.freq = S_freq_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_setFrequency(S_config_reg.freq);
@@ -180,7 +180,7 @@ STX_return HAL_S_setFreq(float S_freq_new) {
 
 STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new) {
     S_config_reg.PA_Power = S_PA_Power_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_setPaPower(S_config_reg.PA_Power);
@@ -189,7 +189,7 @@ STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new) {
 
 STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new) {
     S_config_reg.PA = S_PA_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_setControl(S_config_reg.PA.status, S_config_reg.PA.mode);
@@ -198,10 +198,10 @@ STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new) {
 
 STX_return HAL_S_setEncoder(Sband_Encoder S_enc_new) {
     S_config_reg.enc = S_enc_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
-    return STX_setEncoder(S_config_reg.enc.bit_order, S_config_reg.enc.scrambler, S_config_reg.enc.filter, S_config_reg.enc.modulation,
-                          S_config_reg.enc.rate);
+    return STX_setEncoder(S_config_reg.enc.bit_order, S_config_reg.enc.scrambler, S_config_reg.enc.filter,
+                          S_config_reg.enc.modulation, S_config_reg.enc.rate);
 #endif
 }

--- a/ex2_services/Services/source/housekeeping/housekeeping_service.c
+++ b/ex2_services/Services/source/housekeeping/housekeeping_service.c
@@ -389,15 +389,15 @@ Result mock_everyone(All_systems_housekeeping *all_hk_data) {
 
 Result collect_hk_from_devices(All_systems_housekeeping *all_hk_data) {
 /*populate struct by calling appropriate functions*/
-#ifndef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 0
     ADCS_returnState ADCS_return_code = HAL_ADCS_getHK(&all_hk_data->adcs_hk); /* ADCS Housekeeping */
 #endif                                                                         /* ADCS_IS_STUBBED */
 
-#ifndef ATHENA_IS_STUBBED
+#if ATHENA_IS_STUBBED == 0
     int Athena_return_code = Athena_getHK(&all_hk_data->Athena_hk); /* Athena Housekeeping */
 #endif                                                              /* ATHENA_IS_STUBBED */
 
-#ifndef EPS_IS_STUBBED
+#if EPS_IS_STUBBED == 0
     SAT_returnState EPS_return_code = SATR_OK;
     if (eps_refresh_instantaneous_telemetry() != SATR_OK)
         EPS_return_code = SATR_ERROR;
@@ -406,7 +406,7 @@ Result collect_hk_from_devices(All_systems_housekeeping *all_hk_data) {
     EPS_getHK(&all_hk_data->EPS_hk, &all_hk_data->EPS_startup_hk); /* EPS Housekeeping */
 #endif                                                             /* EPS_IS_STUBBED */
 
-#ifndef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 0
     UHF_return UHF_return_code;
     if (!uhf_is_busy()) {
         UHF_return_code = UHF_getHK(&all_hk_data->UHF_hk); /* UHF Housekeeping */
@@ -414,30 +414,30 @@ Result collect_hk_from_devices(All_systems_housekeeping *all_hk_data) {
     }
 #endif /* UHF_IS_STUBBED */
 
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     STX_return STX_return_code = HAL_S_getHK(&all_hk_data->S_band_hk); /* SBAND Housekeeping */
 #endif                                                                 /* SBAND_IS_STUBBED */
 
-#ifndef HYPERION_IS_STUBBED
-#ifdef HYPERION_PANEL_3U
+#if HYPERION_IS_STUBBED == 0
+#if HYPERION_PANEL_3U == 1
     Hyperion_config1_getHK(&all_hk_data->hyperion_hk); /* Hyperion 3U Housekeeping */
 #endif                                                 /* HYPERION_PANEL_3U */
 
-#ifdef HYPERION_PANEL_2U
+#if HYPERION_PANEL_2U == 1
     Hyperion_config3_getHK(&all_hk_data->hyperion_hk); /* Hyperion 2U Housekeeping */
 #endif                                                 /* HYPERION_PANEL_2U */
 #endif                                                 /* HYPERION_IS_STUBBED */
 
-#ifndef CHARON_IS_STUBBED
+#if CHARON_IS_STUBBED == 0
     GPS_RETURNSTATE Charon_return_code = Charon_getHK(&all_hk_data->charon_hk); /* Charon Houskeeping */
 #endif                                                                          /* CHARON_IS_STUBBED */
 
-#ifndef DFGM_IS_STUBBED
+#if DFGM_IS_STUBBED == 0
     DFGM_return DFGM_return_code = HAL_DFGM_get_HK(&all_hk_data->DFGM_hk); /* DFGM Housekeeping */
 #endif                                                                     /* DFGM_IS_STUBBED */
 
-#ifndef PAYLOAD_IS_STUBBED
-#ifdef IS_EXALTA2
+#if PAYLOAD_IS_STUBBED == 0
+#if IS_EXALTA2 == 1
     // Iris housekeeping
 #else
     NS_return NS_return_code = HAL_NS_get_telemetry(&all_hk_data->NS_hk);
@@ -527,11 +527,11 @@ Result load_config() {
  *    uint16_t of the size of the structure
  */
 uint16_t get_size_of_housekeeping(All_systems_housekeeping *all_hk_data) {
-    uint16_t needed_size =
-        sizeof(all_hk_data->hk_timeorder) + sizeof(all_hk_data->Athena_hk) + sizeof(all_hk_data->EPS_hk) +
-        sizeof(all_hk_data->UHF_hk) + sizeof(all_hk_data->S_band_hk) + sizeof(all_hk_data->adcs_hk) +
-        sizeof(all_hk_data->hyperion_hk) + sizeof(all_hk_data->charon_hk) + sizeof(all_hk_data->DFGM_hk) +
-        sizeof(all_hk_data->NS_hk);
+    uint16_t needed_size = sizeof(all_hk_data->hk_timeorder) + sizeof(all_hk_data->Athena_hk) +
+                           sizeof(all_hk_data->EPS_hk) + sizeof(all_hk_data->UHF_hk) +
+                           sizeof(all_hk_data->S_band_hk) + sizeof(all_hk_data->adcs_hk) +
+                           sizeof(all_hk_data->hyperion_hk) + sizeof(all_hk_data->charon_hk) +
+                           sizeof(all_hk_data->DFGM_hk) + sizeof(all_hk_data->NS_hk);
     return needed_size;
 }
 

--- a/ex2_system/source/beacon/beacon_task.c
+++ b/ex2_system/source/beacon/beacon_task.c
@@ -80,7 +80,7 @@ static void *beacon_daemon(All_systems_housekeeping *all_hk_data) {
         // by the operator or here through HAL_UHF_getBeaconT().
         HAL_UHF_setSCW(scw);
 
-#ifndef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 0
         uhf_status = HAL_UHF_getSCW(scw);
 
         if (uhf_status == U_GOOD_CONFIG) {
@@ -88,7 +88,7 @@ static void *beacon_daemon(All_systems_housekeeping *all_hk_data) {
             uhf_status = HAL_UHF_setSCW(scw);
         }
 #endif
-#ifndef EPS_IS_STUBBED
+#if EPS_IS_STUBBED == 0
         if (uhf_status != U_GOOD_CONFIG) {
 
             if (eps_get_pwr_chnl(UHF_5V0_PWR_CHNL) == 1 && gioGetBit(UHF_GIO_PORT, UHF_GIO_PIN) == 1) {

--- a/ex2_system/source/diagnostic/diagnostic.c
+++ b/ex2_system/source/diagnostic/diagnostic.c
@@ -57,7 +57,7 @@ static SemaphoreHandle_t charon_watchdog_mtx = NULL;
 static SemaphoreHandle_t adcs_watchdog_mtx = NULL;
 static SemaphoreHandle_t ns_watchdog_mtx = NULL;
 
-#ifndef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 0
 /**
  * @brief Check that the UHF is responsive. If not, toggle power.
  *
@@ -79,7 +79,7 @@ static void uhf_watchdog_daemon(void *pvParameters) {
             } else if (err == U_IN_PIPE) {
                 break;
             }
-            vTaskDelay(2*ONE_SECOND);
+            vTaskDelay(2 * ONE_SECOND);
         }
 
         if (err == U_IN_PIPE) {
@@ -123,7 +123,7 @@ static void uhf_watchdog_daemon(void *pvParameters) {
 }
 #endif
 
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
 /**
  * @brief Check that the SBAND is responsive. If not, toggle power.
  *
@@ -142,8 +142,9 @@ static void sband_watchdog_daemon(void *pvParameters) {
         STX_return err;
         for (int i = 0; i < watchdog_retries; i++) {
             STX_getFirmwareV(&SBAND_version);
-            if (SBAND_version != 0) break;
-            vTaskDelay(2*ONE_SECOND);
+            if (SBAND_version != 0)
+                break;
+            vTaskDelay(2 * ONE_SECOND);
         }
         if (SBAND_version == 0) {
             // TODO: Currently no way for power toggling to return fail
@@ -175,7 +176,7 @@ static void sband_watchdog_daemon(void *pvParameters) {
 }
 #endif
 
-#if !defined(CHARON_IS_STUBBED) && defined(IS_EXALTA2)
+#if CHARON_IS_STUBBED == 0 && IS_EXALTA2 == 1
 /**
  * @brief Check that Charon is responsive. If not, toggle power.
  *
@@ -196,8 +197,9 @@ static void charon_watchdog_daemon(void *pvParameters) {
         GPS_RETURNSTATE err;
         for (int i = 0; i < watchdog_retries; i++) {
             err = gps_skytraq_get_software_version(&version);
-            if (err == GPS_SUCCESS) break;
-            vTaskDelay(2*ONE_SECOND);
+            if (err == GPS_SUCCESS)
+                break;
+            vTaskDelay(2 * ONE_SECOND);
         }
 
         if ((err != GPS_SUCCESS) || (version == NULL)) {
@@ -239,7 +241,7 @@ static void charon_watchdog_daemon(void *pvParameters) {
 }
 #endif
 
-#ifndef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 0
 /**
  * @brief Check that the ADCS is responsive. If not, toggle power.
  *
@@ -258,12 +260,13 @@ static void adcs_watchdog_daemon(void *pvParameters) {
 
         ADCS_boot_program_stat test_stat;
 
-
         ADCS_returnState err;
         for (int i = 0; i < watchdog_retries; i++) {
-            err = HAL_ADCS_get_boot_program_stat(&test_stat); // Chosen bc the ADCS will respond in boot and app mode
-            if (err == ADCS_OK) break;
-            vTaskDelay(2*ONE_SECOND);
+            err =
+                HAL_ADCS_get_boot_program_stat(&test_stat); // Chosen bc the ADCS will respond in boot and app mode
+            if (err == ADCS_OK)
+                break;
+            vTaskDelay(2 * ONE_SECOND);
         }
 
         if ((err != ADCS_OK) && (err != ADCS_UART_BUSY)) {
@@ -307,9 +310,9 @@ static void adcs_watchdog_daemon(void *pvParameters) {
 }
 #endif
 
-#ifndef PAYLOAD_IS_STUBBED
-#ifdef IS_EXALTA2
-    // Iris watchdog
+#if PAYLOAD_IS_STUBBED == 0
+#if IS_EXALTA2 == 1
+// Iris watchdog
 #endif
 /**
  * @brief Check that the northern spirit payload is responsive. If not, toggle power.
@@ -331,8 +334,9 @@ static void ns_watchdog_daemon(void *pvParameters) {
         uint8_t heartbeat;
         for (int i = 0; i < watchdog_retries; i++) {
             err = HAL_NS_get_heartbeat(&heartbeat);
-            if (err == NS_OK) break;
-            vTaskDelay(10*ONE_SECOND);
+            if (err == NS_OK)
+                break;
+            vTaskDelay(10 * ONE_SECOND);
         }
 
         if (err != NS_OK) {
@@ -377,7 +381,7 @@ static void ns_watchdog_daemon(void *pvParameters) {
 #endif
 
 TickType_t get_uhf_watchdog_delay(void) {
-#ifdef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 1
     return STUBBED_WATCHDOG_DELAY;
 #else
     if (xSemaphoreTake(uhf_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -391,7 +395,7 @@ TickType_t get_uhf_watchdog_delay(void) {
 }
 
 TickType_t get_sband_watchdog_delay(void) {
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return STUBBED_WATCHDOG_DELAY;
 #else
     if (xSemaphoreTake(sband_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -405,7 +409,7 @@ TickType_t get_sband_watchdog_delay(void) {
 }
 
 TickType_t get_charon_watchdog_delay(void) {
-#ifdef CHARON_IS_STUBBED
+#if CHARON_IS_STUBBED == 1
     return STUBBED_WATCHDOG_DELAY;
 #else
     if (xSemaphoreTake(charon_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -419,7 +423,7 @@ TickType_t get_charon_watchdog_delay(void) {
 }
 
 TickType_t get_adcs_watchdog_delay(void) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return STUBBED_WATCHDOG_DELAY;
 #else
     if (xSemaphoreTake(adcs_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -433,7 +437,7 @@ TickType_t get_adcs_watchdog_delay(void) {
 }
 
 TickType_t get_ns_watchdog_delay(void) {
-#ifdef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 1
     return STUBBED_WATCHDOG_DELAY;
 #else
     if (xSemaphoreTake(ns_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -447,10 +451,10 @@ TickType_t get_ns_watchdog_delay(void) {
 }
 
 SAT_returnState set_uhf_watchdog_delay(const unsigned int ms_delay) {
-#ifdef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 1
     return SATR_OK;
 #else
-    if(ms_delay < WATCHDOG_MINIMUM_DELAY_MS){
+    if (ms_delay < WATCHDOG_MINIMUM_DELAY_MS) {
         return SATR_ERROR;
     }
     if (xSemaphoreTake(uhf_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -463,10 +467,10 @@ SAT_returnState set_uhf_watchdog_delay(const unsigned int ms_delay) {
 }
 
 SAT_returnState set_sband_watchdog_delay(const unsigned int ms_delay) {
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return SATR_OK;
 #else
-    if(ms_delay < WATCHDOG_MINIMUM_DELAY_MS){
+    if (ms_delay < WATCHDOG_MINIMUM_DELAY_MS) {
         return SATR_ERROR;
     }
     if (xSemaphoreTake(sband_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -479,10 +483,10 @@ SAT_returnState set_sband_watchdog_delay(const unsigned int ms_delay) {
 }
 
 SAT_returnState set_charon_watchdog_delay(const unsigned int ms_delay) {
-#ifdef CHARON_IS_STUBBED
+#if CHARON_IS_STUBBED == 1
     return SATR_OK;
 #else
-    if(ms_delay < WATCHDOG_MINIMUM_DELAY_MS){
+    if (ms_delay < WATCHDOG_MINIMUM_DELAY_MS) {
         return SATR_ERROR;
     }
     if (xSemaphoreTake(charon_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -495,10 +499,10 @@ SAT_returnState set_charon_watchdog_delay(const unsigned int ms_delay) {
 }
 
 SAT_returnState set_adcs_watchdog_delay(const unsigned int ms_delay) {
-#ifdef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 1
     return SATR_OK;
 #else
-    if(ms_delay < WATCHDOG_MINIMUM_DELAY_MS){
+    if (ms_delay < WATCHDOG_MINIMUM_DELAY_MS) {
         return SATR_ERROR;
     }
     if (xSemaphoreTake(adcs_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -511,10 +515,10 @@ SAT_returnState set_adcs_watchdog_delay(const unsigned int ms_delay) {
 }
 
 SAT_returnState set_ns_watchdog_delay(const unsigned int ms_delay) {
-#ifdef PAYLOAD_IS_STUBBED
+#if PAYLOAD_IS_STUBBED == 1
     return SATR_OK;
 #else
-    if(ms_delay < WATCHDOG_MINIMUM_DELAY_MS){
+    if (ms_delay < WATCHDOG_MINIMUM_DELAY_MS) {
         return SATR_ERROR;
     }
     if (xSemaphoreTake(ns_watchdog_mtx, mutex_timeout) == pdPASS) {
@@ -526,7 +530,6 @@ SAT_returnState set_ns_watchdog_delay(const unsigned int ms_delay) {
 #endif
 }
 
-
 /**
  * Start the diagnostics daemon
  *
@@ -534,7 +537,7 @@ SAT_returnState set_ns_watchdog_delay(const unsigned int ms_delay) {
  *   error report of task creation
  */
 SAT_returnState start_diagnostic_daemon(void) {
-#ifndef UHF_IS_STUBBED
+#if UHF_IS_STUBBED == 0
     if (xTaskCreate((TaskFunction_t)uhf_watchdog_daemon, "uhf_watchdog_daemon", 1000, NULL, DIAGNOSTIC_TASK_PRIO,
                     NULL) != pdPASS) {
         ex2_log("FAILED TO CREATE TASK uhf_watchdog_daemon.\n");
@@ -548,7 +551,7 @@ SAT_returnState start_diagnostic_daemon(void) {
     }
 #endif
 
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     if (xTaskCreate((TaskFunction_t)sband_watchdog_daemon, "sband_watchdog_daemon", 1000, NULL,
                     DIAGNOSTIC_TASK_PRIO, NULL) != pdPASS) {
         ex2_log("FAILED TO CREATE TASK sband_watchdog_daemon.\n");
@@ -562,7 +565,7 @@ SAT_returnState start_diagnostic_daemon(void) {
     }
 #endif
 
-#if !defined(CHARON_IS_STUBBED) && defined(IS_EXALTA2)
+#if CHARON_IS_STUBBED == 0 && IS_EXALTA2 == 1
     if (xTaskCreate(charon_watchdog_daemon, "charon_watchdog_daemon", 1000, NULL, DIAGNOSTIC_TASK_PRIO, NULL) !=
         pdPASS) {
         ex2_log("FAILED TO CREATE TASK charon_watchdog_daemon.\n");
@@ -576,7 +579,7 @@ SAT_returnState start_diagnostic_daemon(void) {
     }
 #endif
 
-#ifndef ADCS_IS_STUBBED
+#if ADCS_IS_STUBBED == 0
     if (xTaskCreate(adcs_watchdog_daemon, "adcs_watchdog_daemon", 1000, NULL, DIAGNOSTIC_TASK_PRIO, NULL) !=
         pdPASS) {
         ex2_log("FAILED TO CREATE TASK adcs_watchdog_daemon.\n");
@@ -590,11 +593,10 @@ SAT_returnState start_diagnostic_daemon(void) {
     }
 #endif
 
-#ifndef PAYLOAD_IS_STUBBED
-#ifdef IS_EXALTA2
+#if PAYLOAD_IS_STUBBED == 0
+#if IS_EXALTA2 == 1
 #else
-    if (xTaskCreate(ns_watchdog_daemon, "ns_watchdog_daemon", 1000, NULL, DIAGNOSTIC_TASK_PRIO, NULL) !=
-        pdPASS) {
+    if (xTaskCreate(ns_watchdog_daemon, "ns_watchdog_daemon", 1000, NULL, DIAGNOSTIC_TASK_PRIO, NULL) != pdPASS) {
         ex2_log("FAILED TO CREATE TASK ns_watchdog_daemon.\n");
         return SATR_ERROR;
     }

--- a/ex2_system/source/logger/logger.c
+++ b/ex2_system/source/logger/logger.c
@@ -189,7 +189,7 @@ static void do_output(const char *str) {
         red_transact("VOL0:");
     }
 
-#ifndef IS_FLATSAT
+#if IS_SATELLITE == 0
     printf("%s", output_string);
 #endif
 }
@@ -207,7 +207,7 @@ static void do_output(const char *str) {
 void sys_log(SysLog_Level level, const char *format, ...) {
     const char *main_name = "MAIN";
     const char *task_name;
-    const char abbreviations[] = { 'P', 'A', 'C', 'E', 'W', 'N', 'I', 'D' };
+    const char abbreviations[] = {'P', 'A', 'C', 'E', 'W', 'N', 'I', 'D'};
 
     if (xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED) {
         return;
@@ -219,7 +219,8 @@ void sys_log(SysLog_Level level, const char *format, ...) {
         task_name = pcTaskGetName(NULL);
     }
 
-    if (level < 0 || level > DEBUG) level = DEBUG;
+    if (level < 0 || level > DEBUG)
+        level = DEBUG;
 
     char buffer[PRINT_BUF_LEN + TASK_NAME_SIZE + LEVEL_LEN] = {0};
 
@@ -228,7 +229,8 @@ void sys_log(SysLog_Level level, const char *format, ...) {
     char *msg = buffer + TASK_NAME_SIZE + LEVEL_LEN;
     vsnprintf(msg, PRINT_BUF_LEN, format, arg);
     va_end(arg);
-    snprintf(buffer, TASK_NAME_SIZE + LEVEL_LEN + PRINT_BUF_LEN, "%c,%.*s,%s", abbreviations[(int) level], TASK_NAME_SIZE, task_name, msg);
+    snprintf(buffer, TASK_NAME_SIZE + LEVEL_LEN + PRINT_BUF_LEN, "%c,%.*s,%s", abbreviations[(int)level],
+             TASK_NAME_SIZE, task_name, msg);
 
     int string_len = strlen(buffer);
     if (buffer[string_len - 1] == '\n') {

--- a/ex2_system/source/task_manager/task_manager.c
+++ b/ex2_system/source/task_manager/task_manager.c
@@ -212,7 +212,7 @@ bool check_tasks_health() {
 }
 
 void feed_dog() {
-#ifndef WATCHDOG_IS_STUBBED
+#if WATCHDOG_IS_STUBBED == 0
     RAISE_PRIVILEGE;
     portENTER_CRITICAL();
     rtiREG1->WDKEY = 0x0000E51AU;
@@ -223,7 +223,7 @@ void feed_dog() {
 }
 
 void start_dog() {
-#ifndef WATCHDOG_IS_STUBBED
+#if WATCHDOG_IS_STUBBED == 0
     RAISE_PRIVILEGE;
     rtiREG1->WDSTATUS = 0xFFU;
     rtiREG1->DWDPRLD = 0xFFFF;
@@ -245,7 +245,7 @@ void sw_watchdog(void *pvParameters) {
         } else {
 
             should_feed = false;
-#ifdef WATCHDOG_IS_STUBBED
+#if WATCHDOG_IS_STUBBED == 1
             ex2_log("Watchdog would have reset");
 #endif
         }

--- a/main/config.h
+++ b/main/config.h
@@ -1,0 +1,92 @@
+/*
+ * config.h
+ *
+ *  Created on: Jul. 2, 2022
+ *      Author: Robert
+ */
+
+#ifndef CONFIG_H_
+#define CONFIG_H_
+
+#define SYSTEM_APP_ID _OBC_APP_ID_
+
+#define IS_ATHENA 0
+#define IS_ATHENA_V2 0
+
+#define IS_SATELLITE 0
+#if IS_SATELLITE == 1
+#define IS_FLATSAT 0
+#define IS_EXALTA2 1
+#define IS_YUKONSAT 0
+#define IS_AURORASAT 0
+#endif
+
+#define EXECUTE_LEOP 0
+
+#define BOOTLOADER_PRESENT 0
+#define GOLDEN_IMAGE 1
+#define WORKING_IMAGE 0
+
+#define HAS_SD_CARD 0
+#if HAS_SD_CARD == 1
+#define SD_CARD_REFORMAT 0
+#endif
+
+#define ATHENA_IS_STUBBED 1
+#define UHF_IS_STUBBED 1
+#define ADCS_IS_STUBBED 1
+#define SBAND_IS_STUBBED 1
+#define EPS_IS_STUBBED 1
+#define HYPERION_IS_STUBBED 1
+#define CHARON_IS_STUBBED 1
+#define DFGM_IS_STUBBED 1
+#define WATCHDOG_IS_STUBBED 1
+#define PAYLOAD_IS_STUBBED 1
+
+#define HYPERION_PANEL_3U 0
+#define HYPERION_PANEL_2U 0
+#define HYPERION_PANEL_2U_LIMITED 0
+
+#define IS_SN0072_EPS 0
+
+#define UHF_USE_I2C_CMDS 1
+
+#define SBAND_COMMERCIAL_FREQUENCY 1
+
+#define ADCS_MAG_FLIGHT_CONFIG 1
+
+#define CSP_FREERTOS 1
+#define CSP_USE_SDR 0
+#define CSP_USE_KISS 1
+
+/* Define SDR_NO_CSP==0 to use CSP for SDR */
+#define SDR_NO_CSP 0
+#define OS_FREERTOS
+
+#define FLATSAT_TEST 0
+
+/**
+ * SANITY CHECKS
+ */
+#if IS_SATELLITE == 1
+#if (IS_EXALTA2 == 1 && IS_AURORASAT == 1) || (IS_EXALTA2 == 1 && IS_YUKONSAT == 1) ||                            \
+    (IS_AURORASAT == 1 && IS_YUKONSAT == 1)
+#error "Too many satellites defined!"
+#elif IS_EXALTA2 == 0 && IS_YUKONSAT == 0 && IS_AURORASAT == 0
+#error "Need to define a satellite!"
+#endif
+#endif
+
+#if GOLDEN_IMAGE == 1 && WORKING_IMAGE == 1
+#error "Must be either GOLDEN_IMAGE or WORKING_IMAGE"
+#endif
+
+#if CSP_FREERTOS == 0
+#error "CSP_FREERTOS must be 1"
+#endif
+
+#if CSP_USE_KISS == 0 && CSP_USE_SDR == 0 || CSP_USE_KISS == 1 && CSP_USE_SDR == 1
+#error "CSP must use one of KISS or SDR"
+#endif /* !defined(CSP_USE_KISS) && !defined(CSP_USE_SDR) || defined(CSP_USE_KISS) && defined(CSP_USE_SDR) */
+
+#endif /* MAIN_CONFIG_H_ */

--- a/main/system.h
+++ b/main/system.h
@@ -25,16 +25,14 @@
 #include <stdint.h>
 #include "FreeRTOS.h"
 
-#ifdef IS_FLATSAT
-#ifndef IS_ATHENA
-#error If IS_FLATSAT is defined then IS_ATHENA must be defined
+#if IS_FLATSAT == 1
+#if IS_ATHENA == 0
+#error If IS_FLATSAT is set then IS_ATHENA must be set
 #endif
-#ifndef HAS_SD_CARD
+#if HAS_SD_CARD == 0
 #warning FlatSat testing requires the SD card on Athena to be present
 #endif
 #endif
-
-#define SYSTEM_APP_ID _OBC_APP_ID_
 
 #define DIAGNOSICS_TASK_PRIORITY (tskIDLE_PRIORITY)
 #define NORMAL_SERVICE_PRIO (tskIDLE_PRIORITY + 1)
@@ -48,14 +46,7 @@
 #define MOCK_RTC_TASK_PRIO (configMAX_PRIORITIES - 1)
 #define TASK_MANAGER_PRIO (tskIDLE_PRIORITY + 3)
 
-#if (defined(IS_EXALTA2) && defined(IS_AURORASAT)) || (defined(IS_EXALTA2) && defined(IS_YUKONSAT)) ||            \
-    (defined(IS_AURORASAT) && defined(IS_YUKONSAT))
-#error "Too many satellites defined!"
-#elif !defined(IS_EXALTA2) && !defined(IS_YUKONSAT) && !defined(IS_AURORASAT)
-#error "Need to define a satellite!"
-#endif
-
-#if defined(IS_ATHENA)
+#if IS_ATHENA == 1
 #define CSP_SCI sciREG2  // UART2
 #define ADCS_SCI sciREG3 // UART4
 #define DFGM_SCI sciREG4 // UART1
@@ -63,7 +54,7 @@
 #if defined(IS_EXALTA2)
 #define GPS_SCI sciREG1 // UART3
 #define PAYLOAD_SCI NULL
-#elif defined(IS_AURORASAT) || defined(IS_YUKONSAT)
+#elif IS_AURORASAT == 1 || IS_YUKONSAT == 1
 #define GPS_SCI NULL
 #define PAYLOAD_SCI sciREG1 // UART3
 #define GPS_SCI NULL
@@ -79,13 +70,13 @@
 #define UHF_SCI CSP_SCI
 #endif
 
-#ifdef IS_ATHENA
+#if IS_ATHENA == 1
 #define PRINTF_SCI NULL
 #else
 #define PRINTF_SCI sciREG1
 #endif
 
-#if defined(IS_ATHENA)
+#if IS_ATHENA == 1
 #define IRIS_CONFIG_SPI spiREG4 // SPI1
 #define IRIS_SPI spiREG5        // SPI3
 #define SBAND_SPI spiREG3       // SPI2
@@ -97,7 +88,7 @@
 #define SD_SPI spiREG1          //?
 #endif
 
-#if defined(IS_ATHENA)
+#if IS_ATHENA == 1
 #define IMU_I2C i2cREG2
 #define SOLAR_I2C i2cREG1
 #define TEMPSENSE_I2C i2cREG2
@@ -118,9 +109,6 @@
 #define ADCS_I2C i2cREG1
 #define UHF_I2C i2cREG1
 #endif
-
-/* Define SDR_NO_CSP==0 to use CSP for SDR */
-#define SDR_NO_CSP 0
 
 // watchdog timer expires in 447ms
 #define WDT_DELAY 200            // 200 miliseconds gives a a good window
@@ -149,7 +137,7 @@ typedef enum {
 #define RTC_INT_PIN 2
 
 #define ADCS_5V0_PWR_CHNL 1
-#ifdef IS_SN0072_EPS
+#if IS_SN0072_EPS == 1
 #warning                                                                                                          \
     "IS_SN0072_EPS swaps assignment for channels 2 and 5 because of incorrect output config of the engineering model Nanoavionics EPS, SN 0072"
 #define ADCS_3V3_PWR_CHNL 2
@@ -159,7 +147,7 @@ typedef enum {
 
 #define PYLD_5V0_PWR_CHNL 3
 // Channel 4 was assigned to be 3V3 for 1W UHF in case 2W UHFs didn't work out.
-#ifdef IS_SN0072_EPS
+#if IS_SN0072_EPS == 1
 #define DFGM_5V0_PWR_CHNL 5
 #else
 #define ADCS_3V3_PWR_CHNL 5
@@ -171,8 +159,5 @@ typedef enum {
 #define DEPLOYABLES_5V0_PWR_CHNL 9
 #define PYLD_3V3_PWR_CHNL 10
 // SBAND_PWR_CHNL does not exist as it is on the 5V_AO (always on) channel
-
-int ex2_main(void);
-void SciSendBuf(char *buf, uint32_t bufSize);
 
 #endif /* SYSTEM_H */

--- a/source/HL_notification.c
+++ b/source/HL_notification.c
@@ -223,7 +223,7 @@ void sciNotification(sciBASE_t *sci, uint32 flags)
 /* USER CODE BEGIN (32) */
     uint32_t int_reg = (uint32_t)sci;
     switch(int_reg) {
-#ifdef IS_EXALTA2
+#if IS_EXALTA2 == 1
     case (uint32_t)GPS_SCI: gps_sciNotification(sci, flags); break;
 #else
     case (uint32_t)PAYLOAD_SCI: ns_sciNotification(sci, flags); break;


### PR DESCRIPTION
We often have trouble with .cproject merge conflicts. This will help reduce that
The config file is set as a pre-include, so it's included in all files, no #include directive needed
The predefined symbols were also not self-explanatory, needing a spreadsheet to keep track of them. That spreadsheet is now irrelevant
Configurations can now be easily changed in config.h