### PR TITLE
s-band tx infrastructure

### DIFF
--- a/ex2_hal/sband/equipment_handler/include/sTransmitter.h
+++ b/ex2_hal/sband/equipment_handler/include/sTransmitter.h
@@ -26,7 +26,20 @@
 #include "HL_het.h"
 #include "HL_gio.h"
 #include "system.h"
-#include "sband.h"
+
+typedef enum {
+    S_SUCCESS = 0,
+
+    // Returned if a read or write command fails
+    S_BAD_READ = 1,
+    S_BAD_WRITE = 2,
+
+    // Returned if an invalid parameter is passed to a write command at the EH
+    S_BAD_PARAM = 3,
+
+    // Returned at HAL if S-band is stubbed
+    IS_STUBBED_S = 0,
+} STX_return;
 
 #define SBAND_I2C_ADD 0x26
 
@@ -159,6 +172,17 @@
 #define S_POWER_BITMASK 0x0FFF   // Output power and PA Temp are 12-bit values
 #define S_VOLTAGE_BITMASK 0x1FFF // Voltage is a 13-bit value
 
+typedef struct __attribute__((packed)) sband_housekeeping {
+    float Output_Power;
+    float PA_Temp;
+    float Top_Temp;
+    float Bottom_Temp;
+    float Bat_Current;
+    float Bat_Voltage;
+    float PA_Current;
+    float PA_Voltage;
+} Sband_Housekeeping;
+
 STX_return read_reg(uint8_t, uint8_t *);
 STX_return write_reg(uint8_t, uint8_t);
 
@@ -199,6 +223,6 @@ STX_return STX_getTR(uint8_t *transmit);
 
 STX_return STX_getBuffer(uint8_t quantity, uint16_t *ptr);
 
-STX_return STX_getHK(Sband_Housekeeping *hk);
+STX_return STX_getHK(struct sband_housekeeping *hk);
 
 #endif /* STRANSMITTER_H */

--- a/ex2_hal/sband/equipment_handler/include/sTransmitter.h
+++ b/ex2_hal/sband/equipment_handler/include/sTransmitter.h
@@ -25,21 +25,8 @@
 
 #include "HL_het.h"
 #include "HL_gio.h"
+#include "hal_sband.h"
 #include "system.h"
-
-typedef enum {
-    S_SUCCESS = 0,
-
-    // Returned if a read or write command fails
-    S_BAD_READ = 1,
-    S_BAD_WRITE = 2,
-
-    // Returned if an invalid parameter is passed to a write command at the EH
-    S_BAD_PARAM = 3,
-
-    // Returned at HAL if S-band is stubbed
-    IS_STUBBED_S = 0,
-} STX_return;
 
 #define SBAND_I2C_ADD 0x26
 
@@ -138,11 +125,6 @@ typedef enum {
 #define S_FREQ_NOLOCK 0
 #define S_FREQ_LOCK 1
 
-// Buffer parameter types
-#define S_BUFFER_COUNT 0
-#define S_BUFFER_UNDERRUN 1
-#define S_BUFFER_OVERRUN 2
-
 // Conversion factors
 #define S_FREQ_OFFSET_SCALING 2
 #define S_FWVER_MAJORNUM_SCALING 100
@@ -171,17 +153,6 @@ typedef enum {
 #define S_TEMP_BITSHIFT 4        // Temps are stored in the first bits across their two 8-bit registers
 #define S_POWER_BITMASK 0x0FFF   // Output power and PA Temp are 12-bit values
 #define S_VOLTAGE_BITMASK 0x1FFF // Voltage is a 13-bit value
-
-typedef struct __attribute__((packed)) sband_housekeeping {
-    float Output_Power;
-    float PA_Temp;
-    float Top_Temp;
-    float Bottom_Temp;
-    float Bat_Current;
-    float Bat_Voltage;
-    float PA_Current;
-    float PA_Voltage;
-} Sband_Housekeeping;
 
 STX_return read_reg(uint8_t, uint8_t *);
 STX_return write_reg(uint8_t, uint8_t);

--- a/ex2_hal/sband/equipment_handler/source/sTransmitter.c
+++ b/ex2_hal/sband/equipment_handler/source/sTransmitter.c
@@ -512,13 +512,13 @@ STX_return STX_getBuffer(uint8_t quantity, uint16_t *ptr) {
     uint8_t address = 0;
 
     switch (quantity) {
-    case 0: // Buffer Count
+    case S_BUFFER_COUNT: // Buffer Count
         address = S_BUFCNT_REG_1;
         break;
-    case 1: // Buffer Underrun
+    case S_BUFFER_UNDERRUN: // Buffer Underrun
         address = S_BUFUND_REG_1;
         break;
-    case 2: // Buffer Overrun
+    case S_BUFFER_OVERRUN: // Buffer Overrun
         address = S_BUFOVR_REG_1;
         break;
     default:

--- a/ex2_hal/sband/equipment_handler/source/sTransmitter.c
+++ b/ex2_hal/sband/equipment_handler/source/sTransmitter.c
@@ -506,7 +506,7 @@ STX_return STX_getTR(uint8_t *transmit) {
  * @return STX_return
  *      Success of the function defined in sTransmitter.h
  */
-STX_return STX_getBuffer(uint8_t quantity, uint16_t *ptr) {
+STX_return STX_getBuffer(Sband_Buffer_t quantity, uint16_t *ptr) {
     uint8_t rawValue1 = 0;
     uint8_t rawValue2 = 0;
     uint8_t address = 0;
@@ -529,10 +529,10 @@ STX_return STX_getBuffer(uint8_t quantity, uint16_t *ptr) {
         return S_BAD_READ;
     } else if (read_reg(address + 1, &rawValue2) != S_SUCCESS) {
         return S_BAD_READ;
-    } else {
-        *ptr = append_bytes(rawValue1, rawValue2);
-        return S_SUCCESS;
     }
+
+    *ptr = append_bytes(rawValue1, rawValue2);
+    return S_SUCCESS;
 }
 
 /**

--- a/ex2_hal/sband/equipment_handler/test/sband_binary_tests.c
+++ b/ex2_hal/sband/equipment_handler/test/sband_binary_tests.c
@@ -72,7 +72,7 @@ STX_return sband_binary_test(){
     ret = STX_setControl(S_PA_ENABLE, S_SYNC_MODE);
     if(ret != S_SUCCESS) return ret;
 
-    for(int k = 0; k++; k<25){
+    for(int k = 0; k<25; k++){
         message_16[k] = (message[2*k] << 8) || message[2*k+1];
         filler_16[k] = (filler[2*k] << 8) || filler[2*k+1];
     }
@@ -166,7 +166,7 @@ STX_return sband_inf_tx(){
    ret = STX_setControl(S_PA_ENABLE, S_SYNC_MODE);
    if(ret != S_SUCCESS) return ret;
 
-   for(int k = 0; k++; k<25){
+   for(int k = 0; k<25; k++){
        message_16[k] = (message[2*k] << 8) || message[2*k+1];
        filler_16[k] = (filler[2*k] << 8) || filler[2*k+1];
    }

--- a/ex2_hal/sband/equipment_handler/test/sband_binary_tests.c
+++ b/ex2_hal/sband/equipment_handler/test/sband_binary_tests.c
@@ -48,15 +48,15 @@ STX_return sband_binary_test(){
     if(ret != S_SUCCESS) return ret;
     printf("S-band frequency: %f\n", freq);
 
-    ret = STX_getBuffer(0, &count);
+    ret = STX_getBuffer(S_BUFFER_COUNT, &count);
     if(ret != S_SUCCESS) return ret;
     printf("Buffer count: %d\n", count);
 
-    ret = STX_getBuffer(1, &underrun);
+    ret = STX_getBuffer(S_BUFFER_UNDERRUN, &underrun);
     if(ret != S_SUCCESS) return ret;
     printf("Buffer underrun: %d\n", underrun);
 
-    ret = STX_getBuffer(2, &overrun);
+    ret = STX_getBuffer(S_BUFFER_OVERRUN, &overrun);
     if(ret != S_SUCCESS) return ret;
     printf("Buffer overrun: %d\n\n", overrun);
 

--- a/ex2_hal/sband/hardware_interface/include/hal_sband.h
+++ b/ex2_hal/sband/hardware_interface/include/hal_sband.h
@@ -17,24 +17,39 @@
 
 #include <inttypes.h>
 #include "HL_reg_het.h"
-#include <sTransmitter.h>
 
 typedef enum {
-    COUNT = S_BUFFER_COUNT,
-    UNDERRUN = S_BUFFER_UNDERRUN,
-    OVERRUN = S_BUFFER_OVERRUN,
-} Buffer_Quantity;
+    S_SUCCESS = 0,
+
+    // Returned if a read or write command fails
+    S_BAD_READ = 1,
+    S_BAD_WRITE = 2,
+
+    // Returned if an invalid parameter is passed to a write command at the EH
+    S_BAD_PARAM = 3,
+
+    // Returned at HAL if S-band is stubbed
+    IS_STUBBED_S = 0,
+} STX_return;
+
+// Buffer parameter types
+typedef enum {
+    S_BUFFER_COUNT = 0,
+    S_BUFFER_UNDERRUN,
+    S_BUFFER_OVERRUN,
+    S_BUFFER_LAST
+} Sband_Buffer_t;
 
 typedef enum {
     PA_STATUS_DISABLE = 0,
-    PA_STATUS_ENABLE = 1
+    PA_STATUS_ENABLE
 } Sband_PowerAmplifier_Status_t;
 
 typedef enum {
     PA_MODE_CONF = 0,
-    PA_MODE_SYNC = 1,
-    PA_MODE_DATA = 2,
-    PA_MODE_TEST = 3
+    PA_MODE_SYNC,
+    PA_MODE_DATA,
+    PA_MODE_TEST
 } Sband_Transmitter_Mode_t;
 
 typedef struct __attribute__((packed)) {
@@ -71,8 +86,19 @@ typedef struct __attribute__((packed)) {
 } Sband_FirmwareV;
 
 typedef struct __attribute__((packed)) {
-    uint16_t pointer[3];
+    uint16_t pointer[S_BUFFER_LAST];
 } Sband_Buffer;
+
+typedef struct __attribute__((packed)) sband_housekeeping {
+    float Output_Power;
+    float PA_Temp;
+    float Top_Temp;
+    float Bottom_Temp;
+    float Bat_Current;
+    float Bat_Voltage;
+    float PA_Current;
+    float PA_Voltage;
+} Sband_Housekeeping;
 
 typedef struct __attribute__((packed)) {
     Sband_Status status;
@@ -89,6 +115,7 @@ STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc);
 STX_return HAL_S_getStatus(Sband_Status *S_status);
 STX_return HAL_S_getTR(Sband_TR *S_transmit);
 STX_return HAL_S_getHK(Sband_Housekeeping *S_hk);
+STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV);
 STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk);
 STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer);
 STX_return HAL_S_softResetFPGA(void);

--- a/ex2_hal/sband/hardware_interface/include/hal_sband.h
+++ b/ex2_hal/sband/hardware_interface/include/hal_sband.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021-2022  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef HAL_SBAND_H
+#define HAL_SBAND_H
+
+#include <inttypes.h>
+#include "HL_reg_het.h"
+#include <sTransmitter.h>
+
+typedef enum {
+    COUNT = S_BUFFER_COUNT,
+    UNDERRUN = S_BUFFER_UNDERRUN,
+    OVERRUN = S_BUFFER_OVERRUN,
+} Buffer_Quantity;
+
+typedef enum {
+    PA_STATUS_DISABLE = 0,
+    PA_STATUS_ENABLE = 1
+} Sband_PowerAmplifier_Status_t;
+
+typedef enum {
+    PA_MODE_CONF = 0,
+    PA_MODE_SYNC = 1,
+    PA_MODE_DATA = 2,
+    PA_MODE_TEST = 3
+} Sband_Transmitter_Mode_t;
+
+typedef struct __attribute__((packed)) {
+    Sband_PowerAmplifier_Status_t status;
+    Sband_Transmitter_Mode_t mode;
+} Sband_PowerAmplifier;
+
+typedef struct __attribute__((packed)) {
+    uint8_t scrambler;
+    uint8_t filter;
+    uint8_t modulation;
+    uint8_t rate;
+    uint8_t bit_order;
+} Sband_Encoder;
+
+typedef struct __attribute__((packed)) {
+    float freq;
+    uint8_t PA_Power;
+    Sband_PowerAmplifier PA;
+    Sband_Encoder enc;
+} Sband_config;
+
+typedef struct __attribute__((packed)) {
+    uint8_t PWRGD;
+    uint8_t TXL;
+} Sband_Status;
+
+typedef struct __attribute__((packed)) {
+    uint8_t transmit;
+} Sband_TR;
+
+typedef struct __attribute__((packed)) {
+    uint16_t firmware;
+} Sband_FirmwareV;
+
+typedef struct __attribute__((packed)) {
+    uint16_t pointer[3];
+} Sband_Buffer;
+
+typedef struct __attribute__((packed)) {
+    Sband_Status status;
+    Sband_TR transmit;
+    Sband_FirmwareV firmware;
+    Sband_Buffer buffer;
+    Sband_Housekeeping HK;
+} Sband_Full_Status;
+
+STX_return HAL_S_getFreq(float *S_freq);
+STX_return HAL_S_getPAPower(uint8_t *S_PA_power);
+STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA);
+STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc);
+STX_return HAL_S_getStatus(Sband_Status *S_status);
+STX_return HAL_S_getTR(Sband_TR *S_transmit);
+STX_return HAL_S_getHK(Sband_Housekeeping *S_hk);
+STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk);
+STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer);
+STX_return HAL_S_softResetFPGA(void);
+STX_return HAL_S_setFreq(float S_freq_new);
+STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new);
+STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new);
+STX_return HAL_S_setEncoder(Sband_Encoder S_enc_new);
+
+#endif /* HAL_SBAND_H */

--- a/ex2_hal/sband/hardware_interface/include/sband.h
+++ b/ex2_hal/sband/hardware_interface/include/sband.h
@@ -20,6 +20,7 @@
  * @author Ron Unrau
  * @date 2022-07-01
  */
+#include <hal_sband.h>
 #include <spi.h>
 
 /* Send an S-Band Sync word every sync interval bytes */

--- a/ex2_hal/sband/hardware_interface/include/sband.h
+++ b/ex2_hal/sband/hardware_interface/include/sband.h
@@ -1,5 +1,8 @@
+#ifndef SBAND_H
+#define SBAND_H
+
 /*
- * Copyright (C) 2021  University of Alberta
+ * Copyright (C) 2022 University of Alberta
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -12,101 +15,28 @@
  * GNU General Public License for more details.
  */
 
-#ifndef SBAND_H
-#define SBAND_H
+/**
+ * @file sband.h
+ * @author Ron Unrau
+ * @date 2022-07-01
+ */
+#include <spi.h>
 
-#include <inttypes.h>
-#include "HL_reg_het.h"
+/* Send an S-Band Sync word every sync interval bytes */
+#define SBAND_SYNC_INTERVAL 8*1024
 
-typedef enum {
-    S_SUCCESS = 0,
+#define SBAND_FIFO_DEPTH 20*1024
 
-    // Returned if a read or write command fails
-    S_BAD_READ = 1,
-    S_BAD_WRITE = 2,
+int sband_init(void);
 
-    // Returned if an invalid parameter is passed to a write command at the EH
-    S_BAD_PARAM = 3,
+bool sband_enter_conf_mode(void);
+bool sband_enter_sync_mode(void);
+bool sband_enter_data_mode(void);
 
-    // Returned at HAL if S-band is stubbed
-    IS_STUBBED_S = 0,
-} STX_return;
+void sband_sync(void);
 
-typedef enum {
-    COUNT = 0,
-    UNDERRUN,
-    OVERRUN,
-} Buffer_Quantity;
+int sband_transmit_ready(void);
 
-typedef struct __attribute__((packed)) {
-    uint8_t status;
-    uint8_t mode;
-} Sband_PowerAmplifier;
-
-typedef struct __attribute__((packed)) {
-    uint8_t scrambler;
-    uint8_t filter;
-    uint8_t modulation;
-    uint8_t rate;
-    uint8_t bit_order;
-} Sband_Encoder;
-
-typedef struct __attribute__((packed)) {
-    float freq;
-    uint8_t PA_Power;
-    Sband_PowerAmplifier PA;
-    Sband_Encoder enc;
-} Sband_config;
-
-typedef struct __attribute__((packed)) {
-    uint8_t PWRGD;
-    uint8_t TXL;
-} Sband_Status;
-
-typedef struct __attribute__((packed)) {
-    uint8_t transmit;
-} Sband_TR;
-
-typedef struct __attribute__((packed)) {
-    uint16_t firmware;
-} Sband_FirmwareV;
-
-typedef struct __attribute__((packed)) {
-    float Output_Power;
-    float PA_Temp;
-    float Top_Temp;
-    float Bottom_Temp;
-    float Bat_Current;
-    float Bat_Voltage;
-    float PA_Current;
-    float PA_Voltage;
-} Sband_Housekeeping;
-
-typedef struct __attribute__((packed)) {
-    uint16_t pointer[3];
-} Sband_Buffer;
-
-typedef struct __attribute__((packed)) {
-    Sband_Status status;
-    Sband_TR transmit;
-    Sband_FirmwareV firmware;
-    Sband_Buffer buffer;
-    Sband_Housekeeping HK;
-} Sband_Full_Status;
-
-STX_return HAL_S_getFreq(float *S_freq);
-STX_return HAL_S_getPAPower(uint8_t *S_PA_power);
-STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA);
-STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc);
-STX_return HAL_S_getStatus(Sband_Status *S_status);
-STX_return HAL_S_getTR(Sband_TR *S_transmit);
-STX_return HAL_S_getHK(Sband_Housekeeping *S_hk);
-STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk);
-STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer);
-STX_return HAL_S_softResetFPGA(void);
-STX_return HAL_S_setFreq(float S_freq_new);
-STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new);
-STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new);
-STX_return HAL_S_setEncoder(Sband_Encoder S_enc_new);
+bool sband_buffer_count(uint16_t *cnt);
 
 #endif /* SBAND_H */

--- a/ex2_hal/sband/hardware_interface/source/hal_sband.c
+++ b/ex2_hal/sband/hardware_interface/source/hal_sband.c
@@ -35,7 +35,7 @@ static Sband_Full_Status S_FS;
 
 STX_return HAL_S_getFreq(float *S_freq) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getFrequency(&S_config_reg.freq);
 #else
     status = IS_STUBBED_S;
@@ -46,7 +46,7 @@ STX_return HAL_S_getFreq(float *S_freq) {
 
 STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getControl(&S_config_reg.PA.status, &S_config_reg.PA.mode);
 #else
     status = IS_STUBBED_S;
@@ -57,7 +57,7 @@ STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA) {
 
 STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getEncoder(&S_config_reg.enc.bit_order, &S_config_reg.enc.scrambler, &S_config_reg.enc.filter, &S_config_reg.enc.modulation,
                             &S_config_reg.enc.rate);
 #else
@@ -69,7 +69,7 @@ STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc) {
 
 STX_return HAL_S_getPAPower(uint8_t *S_PA_Power) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getPaPower(&S_config_reg.PA_Power);
 #else
     status = IS_STUBBED_S;
@@ -80,7 +80,7 @@ STX_return HAL_S_getPAPower(uint8_t *S_PA_Power) {
 
 STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getFirmwareV(&S_FS.firmware.firmware);
 #else
     S_FS.firmware.firmware = 111;
@@ -92,7 +92,7 @@ STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV) {
 
 STX_return HAL_S_getStatus(Sband_Status *S_status) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getStatus(&S_FS.status.PWRGD, &S_FS.status.TXL);
 #else
     S_FS.status.PWRGD = 1;
@@ -105,7 +105,7 @@ STX_return HAL_S_getStatus(Sband_Status *S_status) {
 
 STX_return HAL_S_getTR(Sband_TR *S_transmit) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getTR(&S_FS.transmit.transmit);
 #else
     S_FS.transmit.transmit = 1;
@@ -117,7 +117,7 @@ STX_return HAL_S_getTR(Sband_TR *S_transmit) {
 
 STX_return HAL_S_getHK(Sband_Housekeeping *S_hk) {
     STX_return status;
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getHK(&S_FS.HK);
 #else
     S_FS.HK.Output_Power = 26;
@@ -151,7 +151,7 @@ STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk) {
 STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer) {
     STX_return status;
     /* Although there is no writing data, we can call a function like them*/
-#ifndef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 0
     status = STX_getBuffer(quantity, &S_FS.buffer.pointer[quantity]);
 #else
     S_FS.buffer.pointer[quantity] = quantity;
@@ -162,7 +162,7 @@ STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer) {
 }
 
 STX_return HAL_S_softResetFPGA(void) {
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_softResetFPGA();
@@ -171,7 +171,7 @@ STX_return HAL_S_softResetFPGA(void) {
 
 STX_return HAL_S_setFreq(float S_freq_new) {
     S_config_reg.freq = S_freq_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
     return STX_setFrequency(S_config_reg.freq);
@@ -179,29 +179,32 @@ STX_return HAL_S_setFreq(float S_freq_new) {
 }
 
 STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new) {
-    S_config_reg.PA_Power = S_PA_Power_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
+    S_config_reg.PA_Power = S_PA_Power_new;
     return STX_setPaPower(S_config_reg.PA_Power);
 #endif
 }
 
 STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new) {
     S_config_reg.PA = S_PA_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
-    return STX_setControl(S_config_reg.PA.status, S_config_reg.PA.mode);
+    return STX_setControl((uint8_t) S_config_reg.PA.status, (uint8_t) S_config_reg.PA.mode);
 #endif
 }
 
 STX_return HAL_S_setEncoder(Sband_Encoder S_enc_new) {
-    S_config_reg.enc = S_enc_new;
-#ifdef SBAND_IS_STUBBED
+#if SBAND_IS_STUBBED == 1
     return IS_STUBBED_S;
 #else
-    return STX_setEncoder(S_config_reg.enc.bit_order, S_config_reg.enc.scrambler, S_config_reg.enc.filter, S_config_reg.enc.modulation,
+    S_config_reg.enc = S_enc_new;
+    return STX_setEncoder(S_config_reg.enc.bit_order,
+                          S_config_reg.enc.scrambler,
+                          S_config_reg.enc.filter,
+                          S_config_reg.enc.modulation,
                           S_config_reg.enc.rate);
 #endif
 }

--- a/ex2_hal/sband/hardware_interface/source/hal_sband.c
+++ b/ex2_hal/sband/hardware_interface/source/hal_sband.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2022  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/**
+ * @file hal_sband.c
+ * @author Arash Yazdani
+ * @date 2020-10-01
+ */
+
+/*
+ * When TRX connected, the stubbed blocks can be used for TRX = off situation.
+ */
+#include "hal_sband.h"
+
+#include <string.h>
+#include <FreeRTOS.h>
+#include <csp/csp_endian.h>
+#include <os_queue.h>
+
+#include "services.h"
+
+// For storing the set data
+static Sband_config S_config_reg;
+static Sband_Full_Status S_FS;
+
+STX_return HAL_S_getFreq(float *S_freq) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getFrequency(&S_config_reg.freq);
+#else
+    status = IS_STUBBED_S;
+#endif
+    *S_freq = S_config_reg.freq;
+    return status;
+};
+
+STX_return HAL_S_getControl(Sband_PowerAmplifier *S_PA) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getControl(&S_config_reg.PA.status, &S_config_reg.PA.mode);
+#else
+    status = IS_STUBBED_S;
+#endif
+    *S_PA = S_config_reg.PA;
+    return status;
+};
+
+STX_return HAL_S_getEncoder(Sband_Encoder *S_Enc) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getEncoder(&S_config_reg.enc.bit_order, &S_config_reg.enc.scrambler, &S_config_reg.enc.filter, &S_config_reg.enc.modulation,
+                            &S_config_reg.enc.rate);
+#else
+    status = IS_STUBBED_S;
+#endif
+    *S_Enc = S_config_reg.enc;
+    return status;
+}
+
+STX_return HAL_S_getPAPower(uint8_t *S_PA_Power) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getPaPower(&S_config_reg.PA_Power);
+#else
+    status = IS_STUBBED_S;
+#endif
+    *S_PA_Power = S_config_reg.PA_Power;
+    return status;
+};
+
+STX_return HAL_S_getFirmwareV(Sband_FirmwareV *S_firmwareV) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getFirmwareV(&S_FS.firmware.firmware);
+#else
+    S_FS.firmware.firmware = 111;
+    status = IS_STUBBED_S;
+#endif
+    *S_firmwareV = S_FS.firmware;
+    return status;
+}
+
+STX_return HAL_S_getStatus(Sband_Status *S_status) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getStatus(&S_FS.status.PWRGD, &S_FS.status.TXL);
+#else
+    S_FS.status.PWRGD = 1;
+    S_FS.status.TXL = 1;
+    status = IS_STUBBED_S;
+#endif
+    *S_status = S_FS.status;
+    return status;
+}
+
+STX_return HAL_S_getTR(Sband_TR *S_transmit) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getTR(&S_FS.transmit.transmit);
+#else
+    S_FS.transmit.transmit = 1;
+    status = IS_STUBBED_S;
+#endif
+    *S_transmit = S_FS.transmit;
+    return status;
+}
+
+STX_return HAL_S_getHK(Sband_Housekeeping *S_hk) {
+    STX_return status;
+#ifndef SBAND_IS_STUBBED
+    status = STX_getHK(&S_FS.HK);
+#else
+    S_FS.HK.Output_Power = 26;
+    S_FS.HK.PA_Temp = 27.3;
+    S_FS.HK.Top_Temp = -2.8;
+    S_FS.HK.Bottom_Temp = 11.7;
+    S_FS.HK.Bat_Current = 95;
+    S_FS.HK.Bat_Voltage = 7.2;
+    S_FS.HK.PA_Current = 0.48;
+    S_FS.HK.PA_Voltage = 5.1;
+    status = IS_STUBBED_S;
+#endif
+    *S_hk = S_FS.HK;
+    return status;
+}
+
+STX_return HAL_S_hk_convert_endianness(Sband_Housekeeping *S_hk) {
+    S_hk->Output_Power = csp_htonflt(S_hk->Output_Power);
+    S_hk->PA_Temp = csp_htonflt(S_hk->PA_Temp);
+    S_hk->Top_Temp = csp_htonflt(S_hk->Top_Temp);
+    S_hk->Bottom_Temp = csp_htonflt(S_hk->Bottom_Temp);
+    S_hk->Bat_Current = csp_htonflt(S_hk->Bat_Current);
+    S_hk->Bat_Voltage = csp_htonflt(S_hk->Bat_Voltage);
+    S_hk->PA_Current = csp_htonflt(S_hk->PA_Current);
+    S_hk->PA_Voltage = csp_htonflt(S_hk->PA_Voltage);
+    S_hk->PA_Voltage = csp_htonflt(S_hk->PA_Voltage);
+    return S_SUCCESS;
+}
+
+/* The switch operation might be better implemented here than in EH */
+STX_return HAL_S_getBuffer(int quantity, Sband_Buffer *S_buffer) {
+    STX_return status;
+    /* Although there is no writing data, we can call a function like them*/
+#ifndef SBAND_IS_STUBBED
+    status = STX_getBuffer(quantity, &S_FS.buffer.pointer[quantity]);
+#else
+    S_FS.buffer.pointer[quantity] = quantity;
+    status = IS_STUBBED_S;
+#endif
+    *S_buffer = S_FS.buffer;
+    return status;
+}
+
+STX_return HAL_S_softResetFPGA(void) {
+#ifdef SBAND_IS_STUBBED
+    return IS_STUBBED_S;
+#else
+    return STX_softResetFPGA();
+#endif
+}
+
+STX_return HAL_S_setFreq(float S_freq_new) {
+    S_config_reg.freq = S_freq_new;
+#ifdef SBAND_IS_STUBBED
+    return IS_STUBBED_S;
+#else
+    return STX_setFrequency(S_config_reg.freq);
+#endif
+}
+
+STX_return HAL_S_setPAPower(uint8_t S_PA_Power_new) {
+    S_config_reg.PA_Power = S_PA_Power_new;
+#ifdef SBAND_IS_STUBBED
+    return IS_STUBBED_S;
+#else
+    return STX_setPaPower(S_config_reg.PA_Power);
+#endif
+}
+
+STX_return HAL_S_setControl(Sband_PowerAmplifier S_PA_new) {
+    S_config_reg.PA = S_PA_new;
+#ifdef SBAND_IS_STUBBED
+    return IS_STUBBED_S;
+#else
+    return STX_setControl(S_config_reg.PA.status, S_config_reg.PA.mode);
+#endif
+}
+
+STX_return HAL_S_setEncoder(Sband_Encoder S_enc_new) {
+    S_config_reg.enc = S_enc_new;
+#ifdef SBAND_IS_STUBBED
+    return IS_STUBBED_S;
+#else
+    return STX_setEncoder(S_config_reg.enc.bit_order, S_config_reg.enc.scrambler, S_config_reg.enc.filter, S_config_reg.enc.modulation,
+                          S_config_reg.enc.rate);
+#endif
+}

--- a/ex2_services/Services/include/housekeeping/housekeeping_service.h
+++ b/ex2_services/Services/include/housekeeping/housekeeping_service.h
@@ -30,7 +30,7 @@
 #include "housekeeping_athena.h"
 #include "housekeeping_charon.h"
 #include "hyperion.h"
-#include "hal_sband.h"
+#include "sband.h"
 #include "uhf.h"
 #include "dfgm.h"
 #include "ns_payload.h"

--- a/ex2_services/Services/include/housekeeping/housekeeping_service.h
+++ b/ex2_services/Services/include/housekeeping/housekeeping_service.h
@@ -30,7 +30,7 @@
 #include "housekeeping_athena.h"
 #include "housekeeping_charon.h"
 #include "hyperion.h"
-#include "sband.h"
+#include "hal_sband.h"
 #include "uhf.h"
 #include "dfgm.h"
 #include "ns_payload.h"

--- a/ex2_services/Services/include/scheduler/scheduler.h
+++ b/ex2_services/Services/include/scheduler/scheduler.h
@@ -109,6 +109,6 @@ SAT_returnState start_scheduler_service(void);
 int calc_cmd_frequency(scheduled_commands_t* cmds, int number_of_cmds, scheduled_commands_unix_t *sorted_cmds);
 SAT_returnState sort_cmds(scheduled_commands_unix_t *sorted_cmds, int number_of_cmds);
 static scheduled_commands_t *prv_get_cmds_scheduler();
-SAT_returnState vSchedulerHandler (void *pvParameters);
+void vSchedulerHandler (void *pvParameters);
 
 #endif /* EX2_SYSTEM_INCLUDE_SCHEDULER_H_ */

--- a/ex2_services/Services/source/communication/communication_service.c
+++ b/ex2_services/Services/source/communication/communication_service.c
@@ -24,7 +24,7 @@
 #include <csp/csp_endian.h>
 #include <main/system.h>
 
-#include "sband.h"
+#include "hal_sband.h"
 #include "services.h"
 #include "task_manager/task_manager.h"
 #include "uhf.h"

--- a/ex2_services/Services/source/communication/communication_service.c
+++ b/ex2_services/Services/source/communication/communication_service.c
@@ -24,10 +24,10 @@
 #include <csp/csp_endian.h>
 #include <main/system.h>
 
-#include "hal_sband.h"
 #include "services.h"
 #include "task_manager/task_manager.h"
 #include "uhf.h"
+#include "sband.h"
 #include "util/service_utilities.h"
 
 #define CHAR_LEN 1 // If using Numpy unicode string, change to 4
@@ -347,8 +347,8 @@ SAT_returnState communication_service_app(csp_packet_t *packet) {
 
     case S_SET_CONTROL: {
         Sband_PowerAmplifier PA;
-        PA.status = (uint8_t)packet->data[IN_DATA_BYTE];
-        PA.mode = (uint8_t)packet->data[IN_DATA_BYTE + 1];
+        PA.status = (Sband_PowerAmplifier_Status_t)packet->data[IN_DATA_BYTE];
+        PA.mode = (Sband_Transmitter_Mode_t)packet->data[IN_DATA_BYTE + 1];
         status = HAL_S_setControl(PA);
         memcpy(&packet->data[STATUS_BYTE], &status, sizeof(int8_t));
         set_packet_length(packet, sizeof(int8_t) + 1);
@@ -374,8 +374,8 @@ SAT_returnState communication_service_app(csp_packet_t *packet) {
         cnv8_F(&packet->data[IN_DATA_BYTE], &S_config.freq);
         S_config.freq = csp_ntohflt(S_config.freq);
         S_config.PA_Power = (uint8_t)packet->data[IN_DATA_BYTE + 4]; // plus 4 because float takes 4B
-        S_config.PA.status = (uint8_t)packet->data[IN_DATA_BYTE + 5];
-        S_config.PA.mode = (uint8_t)packet->data[IN_DATA_BYTE + 6];
+        S_config.PA.status = (Sband_PowerAmplifier_Status_t)packet->data[IN_DATA_BYTE + 5];
+        S_config.PA.mode = (Sband_Transmitter_Mode_t)packet->data[IN_DATA_BYTE + 6];
         S_config.enc.scrambler = (uint8_t)packet->data[IN_DATA_BYTE + 7];
         S_config.enc.filter = (uint8_t)packet->data[IN_DATA_BYTE + 8];
         S_config.enc.modulation = (uint8_t)packet->data[IN_DATA_BYTE + 9];

--- a/ex2_services/Services/source/services.c
+++ b/ex2_services/Services/source/services.c
@@ -65,7 +65,7 @@ SAT_returnState start_service_server(void) {
         start_dfgm_service() != SATR_OK ||
         start_adcs_service() != SATR_OK ||
         start_ns_payload_service() != SATR_OK ||
-        start_FTP_service() != SATR_OK); {
+        start_FTP_service() != SATR_OK) {
         return SATR_ERROR;
     }
     return SATR_OK;

--- a/ex2_system/include/test_sdr.h
+++ b/ex2_system/include/test_sdr.h
@@ -10,6 +10,6 @@
 
 #include "sdr_driver.h"
 
-void start_test_sdr(sdr_interface_data_t *);
+void start_test_sdr(sdr_interface_data_t *uhf, sdr_interface_data_t *sband);
 
 #endif /* EX2_SYSTEM_TEST_SDR_H_ */

--- a/ex2_system/source/housekeeping/housekeeping_to_beacon.c
+++ b/ex2_system/source/housekeeping/housekeeping_to_beacon.c
@@ -110,7 +110,7 @@ void update_beacon(All_systems_housekeeping *all_hk_data, beacon_packet_1_t *bea
         if (athena_MCU_temp_long[i] < -128) {
             athena_MCU_temp_long[i] = -128;
         }
-        if ((athena_MCU_temp_long[i] >> 63) == 1) { // negative
+        if ((athena_MCU_temp_long[i] > 63) == 1) { // negative
             athena_MCU_temp[i] = ((athena_MCU_temp_long[i] & 127) | 128);
         } else { // positive
             athena_MCU_temp[i] = (athena_MCU_temp_long[i] & 127);

--- a/ex2_system/source/scheduler/scheduler_task.c
+++ b/ex2_system/source/scheduler/scheduler_task.c
@@ -30,9 +30,8 @@ extern int delay_aborted;
  * @param pvParameters
  *    scheduleSemaphore, which is the mutex used for protecting the file system from being accessed by multiple threads
  */
-SAT_returnState vSchedulerHandler(SemaphoreHandle_t scheduleSemaphore) {
+void vSchedulerHandler(SemaphoreHandle_t scheduleSemaphore) {
     TickType_t xLastWakeTime;
-    uint8_t hist_file_position = 0;
     int32_t fout, f_stat, f_read, f_write, f_close;
     REDSTAT scheduler_stat;
 

--- a/ex2_system/source/test_sdr.c
+++ b/ex2_system/source/test_sdr.c
@@ -53,7 +53,7 @@ void test_csp_send(void *arg) {
     csp_close(conn);
 }
 
-void test_sdr_send(void *arg) {
+void test_uhf_send(void *arg) {
     sdr_interface_data_t *ifdata = arg;
 
     ex2_log("starting SDR->UART send");
@@ -79,6 +79,38 @@ void test_sdr_send(void *arg) {
         }
         vPortFree(packet);
         vTaskDelay(5000);
+    }
+}
+
+void test_sband_send(void *arg) {
+    sdr_interface_data_t *ifdata = arg;
+    int len = 1024;
+    uint8_t *packet = (uint8_t *) pvPortMalloc(len);
+
+    ex2_log("starting S-BAND send");
+    vTaskDelay(1000);
+
+    while (1) {
+        /* Simulate the sending of 10MB files */
+        sdr_sband_tx_start(ifdata);
+
+        int i, count;
+        for (count=0; count < 10*1024; count++) {
+            for (i=0; i<len; i++) {
+                packet[i] = count & 0x0ff;
+            }
+            ex2_log("sband send %d, len %d", count, len);
+
+            int rc = sdr_sband_tx(ifdata, packet, len);
+            if (rc) {
+                ex2_log("sdr_sband_tx returns %d", rc);
+            }
+        }
+
+        ex2_log("sband rest %d", count/len);
+        sdr_sband_tx_stop(ifdata);
+        vTaskDelay(10000);
+        ex2_log("sband back at it!");
     }
 }
 
@@ -142,14 +174,17 @@ static void sdr_uhf_receive(void *conf, uint8_t *data, size_t len, void *unused)
     ex2_log("uhf->csp %d mismatches", mismatches);
 }
 
-void start_test_sdr(sdr_interface_data_t *ifdata) {
+void start_test_sdr(sdr_interface_data_t *uhf_ifdata, sdr_interface_data_t *sband_ifdata) {
     if (SDR_NO_CSP) {
-        ifdata->sdr_conf->rx_callback = sdr_uhf_receive;
-        ifdata->sdr_conf->rx_callback_data = NULL;
+        uhf_ifdata->sdr_conf->rx_callback = (sdr_rx_callback_t) sdr_uhf_receive;
+        uhf_ifdata->sdr_conf->rx_callback_data = NULL;
 
-        xTaskCreate(test_sdr_send, "sdr->uhf", TEST_STACK_SIZE, ifdata, 0, NULL);
-    } else {
+        xTaskCreate(test_uhf_send, "sdr->uhf", TEST_STACK_SIZE, uhf_ifdata, 0, NULL);
+    }
+    else {
         xTaskCreate(test_csp_receive, "uhf->csp", TEST_STACK_SIZE, NULL, 0, NULL);
         xTaskCreate(test_csp_send, "csp->uhf", TEST_STACK_SIZE, NULL, 0, NULL);
     }
+
+    xTaskCreate(test_sband_send, "sdr->sband", TEST_STACK_SIZE, sband_ifdata, 0, NULL);
 }

--- a/main/config.h
+++ b/main/config.h
@@ -56,8 +56,8 @@
 #define ADCS_MAG_FLIGHT_CONFIG 1
 
 #define CSP_FREERTOS 1
-#define CSP_USE_SDR 0
-#define CSP_USE_KISS 1
+#define CSP_USE_SDR 1
+#define CSP_USE_KISS 0
 
 /* Define SDR_NO_CSP==0 to use CSP for SDR */
 #define SDR_NO_CSP 0

--- a/main/main.c
+++ b/main/main.c
@@ -57,8 +57,7 @@
 #include <os_semphr.h>
 #include "uhf.h"
 #include "eps.h"
-#include "sband.h"
-#include "sTransmitter.h"
+#include "hal_sband.h"
 #include "system.h"
 #include "dfgm.h"
 #include "leop.h"
@@ -73,6 +72,19 @@
 #include "csp_debug_wrapper.h"
 
 #if FLATSAT_TEST == 1
+
+#define SDR_TEST 0
+
+#if SDR_TEST == 1
+#include "test_sdr.h"
+
+static sdr_interface_data_t *test_uhf_ifdata;
+static sdr_interface_data_t *test_sband_ifdata;
+#endif
+
+#define CSP_USE_SDR
+//#define CSP_USE_KISS
+
 //#include "sband_binary_tests.h"
 static void flatsat_test();
 #endif
@@ -149,8 +161,7 @@ void ex2_init(void *pvParameters) {
 #endif
 
 #if SBAND_IS_STUBBED == 0
-    STX_Enable();
-    // PLACEHOLDER: sband hardware init
+    sband_init();
 #endif
 
 #if CHARON_IS_STUBBED == 0
@@ -179,9 +190,9 @@ void ex2_init(void *pvParameters) {
 
     init_software();
 
-#ifdef SDR_TEST
-    start_test_sdr();
-#endif
+ #ifdef SDR_TEST
+    start_test_sdr(test_uhf_ifdata, test_sband_ifdata);
+ #endif
 
 #if FLATSAT_TEST == 1
     /* Test Task */
@@ -355,11 +366,9 @@ static inline SAT_returnState init_csp_interface() {
 
     if (SDR_NO_CSP) {
         sdr_interface_data_t *ifdata = sdr_interface_init(&sdr_conf, gs_if_name);
-        if (!ifdata) {
-            return SATR_ERROR;
-        }
+        if (!ifdata) return SATR_ERROR;
 #if SDR_TEST == 1
-        test_ifdata = ifdata;
+        test_uhf_ifdata = ifdata;
 #endif
     } else {
         error = csp_sdr_open_and_add_interface(&sdr_conf, gs_if_name, NULL);
@@ -369,10 +378,19 @@ static inline SAT_returnState init_csp_interface() {
     }
 
 #if SBAND_IS_STUBBED == 0
+#if SDR_TEST == 1
+    test_sband_ifdata = sdr_interface_init(&sdr_conf, SDR_IF_SBAND_NAME);
+    if (!test_sband_ifdata) return SATR_ERROR;
+#endif
+#endif // !SBAND_IS_STUBBED
+
+#if SBAND_IS_STUBBED == 0
+#if 0
     error = csp_sdr_open_and_add_interface(&sdr_conf, SDR_IF_SBAND_NAME, NULL);
     if (error != CSP_ERR_NONE) {
         return SATR_ERROR;
     }
+#endif
 #endif // SBAND_IS_STUBBED
 #endif /* CSP_USE_SDR */
 

--- a/main/main.c
+++ b/main/main.c
@@ -57,7 +57,7 @@
 #include <os_semphr.h>
 #include "uhf.h"
 #include "eps.h"
-#include "hal_sband.h"
+#include "sband.h"
 #include "system.h"
 #include "dfgm.h"
 #include "leop.h"

--- a/main/main.c
+++ b/main/main.c
@@ -71,8 +71,6 @@
 #include "crypto.h"
 #include "csp_debug_wrapper.h"
 
-#if FLATSAT_TEST == 1
-
 #define SDR_TEST 0
 
 #if SDR_TEST == 1
@@ -80,11 +78,9 @@
 
 static sdr_interface_data_t *test_uhf_ifdata;
 static sdr_interface_data_t *test_sband_ifdata;
-#endif
+#endif // SDR_TEST
 
-#define CSP_USE_SDR
-//#define CSP_USE_KISS
-
+#if FLATSAT_TEST == 1
 //#include "sband_binary_tests.h"
 static void flatsat_test();
 #endif
@@ -190,7 +186,7 @@ void ex2_init(void *pvParameters) {
 
     init_software();
 
- #ifdef SDR_TEST
+ #if SDR_TEST == 1
     start_test_sdr(test_uhf_ifdata, test_sband_ifdata);
  #endif
 
@@ -378,20 +374,18 @@ static inline SAT_returnState init_csp_interface() {
     }
 
 #if SBAND_IS_STUBBED == 0
-#if SDR_TEST == 1
-    test_sband_ifdata = sdr_interface_init(&sdr_conf, SDR_IF_SBAND_NAME);
-    if (!test_sband_ifdata) return SATR_ERROR;
-#endif
-#endif // !SBAND_IS_STUBBED
-
-#if SBAND_IS_STUBBED == 0
 #if 0
     error = csp_sdr_open_and_add_interface(&sdr_conf, SDR_IF_SBAND_NAME, NULL);
     if (error != CSP_ERR_NONE) {
         return SATR_ERROR;
     }
 #endif
-#endif // SBAND_IS_STUBBED
+#endif /* !SBAND_IS_STUBBED */
+
+#if SDR_TEST == 1
+    test_sband_ifdata = sdr_interface_init(&sdr_conf, SDR_IF_SBAND_NAME);
+    if (!test_sband_ifdata) return SATR_ERROR;
+#endif
 #endif /* CSP_USE_SDR */
 
     char rtable[128] = {0};


### PR DESCRIPTION
These changes add STX support functions used by the SDR S-band transmitter. These functions have been tested (a bit) and are independent of the rest of ex2_obc_software, so there is no need to wait to merge the PR.