### PR TITLE
Droog/feature/ina209 implement

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -1569,6 +1569,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.1829865242" name="Designate enum type (--enum_type)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.packed" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH.873460738" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/hardware_interface/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/payload/iris}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/equipment_handler/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/hardware_interface/include}"/>
@@ -1877,6 +1878,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.1918935123" name="Designate enum type (--enum_type)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.packed" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH.2042059691" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/hardware_interface/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/payload/iris}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/equipment_handler/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/hardware_interface/include}"/>
@@ -2185,6 +2187,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.1957518765" name="Designate enum type (--enum_type)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.packed" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH.400997442" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/hardware_interface/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/payload/iris}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/equipment_handler/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/hardware_interface/include}"/>
@@ -2493,6 +2496,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.1993336214" name="Designate enum type (--enum_type)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.packed" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH.1852102578" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/hardware_interface/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/payload/iris}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/equipment_handler/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/hardware_interface/include}"/>

--- a/.cproject
+++ b/.cproject
@@ -37,6 +37,8 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.726053734" name="Designate enum type (--enum_type)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE" value="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.ENUM_TYPE.packed" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH.1617014538" name="Add dir to #include search path (--include_path, -I)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_20.2.compilerID.INCLUDE_PATH" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/main}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/equipment_handler/include}"/>
+									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/athena/hardware_interface/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_services/Services/include/payload/iris}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/equipment_handler/include}"/>
 									<listOptionValue builtIn="false" value="${workspace_loc:/${ProjName}/ex2_hal/iris/hardware_interface/include}"/>

--- a/ex2_hal/athena/equipment_handler/include/ina209.h
+++ b/ex2_hal/athena/equipment_handler/include/ina209.h
@@ -9,9 +9,13 @@
 #define EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_
 
 #include <stdint.h>
+#include <FreeRTOS.h>
+#include <os_task.h>
 
 #define SOLAR_INA209_ADDR 0x40
 #define CORE_V_INA209_ADDR 0x45
+
+#define SOLAR_INA209_STACK_LEN 50 // arbitrary for now
 
 void ina209_get_configuration(uint8_t addr, uint16_t *retval);
 void ina209_set_configuration(uint8_t addr, uint16_t *val);
@@ -37,6 +41,5 @@ void ina209_get_calibration(uint8_t addr, uint16_t *retval);
 void ina209_set_calibration(uint8_t addr, uint16_t *val);
 void init_ina209(uint8_t addr);
 void reset_ina209(uint8_t addr);
-
 
 #endif /* EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_ */

--- a/ex2_hal/athena/equipment_handler/include/ina209.h
+++ b/ex2_hal/athena/equipment_handler/include/ina209.h
@@ -17,29 +17,29 @@
 
 #define SOLAR_INA209_STACK_LEN 1000 // arbitrary for now
 
-void ina209_get_configuration(uint8_t addr, uint16_t *retval);
-void ina209_set_configuration(uint8_t addr, uint16_t *val);
-void ina209_get_status_flags(uint8_t addr, uint16_t *retval);
-void ina209_get_control_register(uint8_t addr, uint16_t *retval);
-void ina209_set_control_register(uint8_t addr, uint16_t *val);
-void ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval);
-void ina209_get_bus_voltage(uint8_t addr, uint16_t *retval);
-void ina209_get_power(uint8_t addr, uint16_t *retval);
-void ina209_get_current(uint8_t addr, uint16_t *retval);
-void ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval);
-void ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval);
-void ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval);
-void ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval);
-void ina209_get_power_peak(uint8_t addr, uint16_t *retval);
-void ina209_get_power_overlimit(uint8_t addr, uint16_t *retval);
-void ina209_set_power_overlimit(uint8_t addr, uint16_t *val);
-void ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval);
-void ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t *val);
-void ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval);
-void ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t *val);
-void ina209_get_calibration(uint8_t addr, uint16_t *retval);
-void ina209_set_calibration(uint8_t addr, uint16_t *val);
-void init_ina209(uint8_t addr);
-void reset_ina209(uint8_t addr);
+int ina209_get_configuration(uint8_t addr, uint16_t *retval);
+int ina209_set_configuration(uint8_t addr, uint16_t *val);
+int ina209_get_status_flags(uint8_t addr, uint16_t *retval);
+int ina209_get_control_register(uint8_t addr, uint16_t *retval);
+int ina209_set_control_register(uint8_t addr, uint16_t *val);
+int ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval);
+int ina209_get_bus_voltage(uint8_t addr, uint16_t *retval);
+int ina209_get_power(uint8_t addr, uint16_t *retval);
+int ina209_get_current(uint8_t addr, uint16_t *retval);
+int ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval);
+int ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval);
+int ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval);
+int ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval);
+int ina209_get_power_peak(uint8_t addr, uint16_t *retval);
+int ina209_get_power_overlimit(uint8_t addr, uint16_t *retval);
+int ina209_set_power_overlimit(uint8_t addr, uint16_t *val);
+int ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval);
+int ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t *val);
+int ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval);
+int ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t *val);
+int ina209_get_calibration(uint8_t addr, uint16_t *retval);
+int ina209_set_calibration(uint8_t addr, uint16_t *val);
+int init_ina209(uint8_t addr);
+int reset_ina209(uint8_t addr);
 
 #endif /* EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_ */

--- a/ex2_hal/athena/equipment_handler/include/ina209.h
+++ b/ex2_hal/athena/equipment_handler/include/ina209.h
@@ -1,0 +1,42 @@
+/*
+ * ina209.h
+ *
+ *  Created on: Jun 23, 2022
+ *      Author: joshd
+ */
+
+#ifndef EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_
+#define EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_
+
+#include <stdint.h>
+
+#define SOLAR_INA209_ADDR 0x40
+#define CORE_V_INA209_ADDR 0x45
+
+void ina209_get_configuration(uint8_t addr, uint16_t *retval);
+void ina209_set_configuration(uint8_t addr, uint16_t *val);
+void ina209_get_status_flags(uint8_t addr, uint16_t *retval);
+void ina209_get_control_register(uint8_t addr, uint16_t *retval);
+void ina209_set_control_register(uint8_t addr, uint16_t *val);
+void ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval);
+void ina209_get_bus_voltage(uint8_t addr, uint16_t *retval);
+void ina209_get_power(uint8_t addr, uint16_t *retval);
+void ina209_get_current(uint8_t addr, uint16_t *retval);
+void ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval);
+void ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval);
+void ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval);
+void ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval);
+void ina209_get_power_peak(uint8_t addr, uint16_t *retval);
+void ina209_get_power_overlimit(uint8_t addr, uint16_t *retval);
+void ina209_set_power_overlimit(uint8_t addr, uint16_t *val);
+void ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval);
+void ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t *val);
+void ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval);
+void ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t *val);
+void ina209_get_calibration(uint8_t addr, uint16_t *retval);
+void ina209_set_calibration(uint8_t addr, uint16_t *val);
+void init_ina209(uint8_t addr);
+void reset_ina209(uint8_t addr);
+
+
+#endif /* EX2_HAL_ATHENA_EQUIPMENT_HANDLER_INCLUDE_INA209_H_ */

--- a/ex2_hal/athena/equipment_handler/include/ina209.h
+++ b/ex2_hal/athena/equipment_handler/include/ina209.h
@@ -15,7 +15,7 @@
 #define SOLAR_INA209_ADDR 0x40
 #define CORE_V_INA209_ADDR 0x45
 
-#define SOLAR_INA209_STACK_LEN 50 // arbitrary for now
+#define SOLAR_INA209_STACK_LEN 1000 // arbitrary for now
 
 void ina209_get_configuration(uint8_t addr, uint16_t *retval);
 void ina209_set_configuration(uint8_t addr, uint16_t *val);

--- a/ex2_hal/athena/equipment_handler/include/tmp421.h
+++ b/ex2_hal/athena/equipment_handler/include/tmp421.h
@@ -13,12 +13,6 @@
 
 #include <stdint.h>
 
-// CODE TO MAYBE BE ADDED TO I2C DRIVERS BELOW
-int i2cSlaveWriteReg(uint8_t sadd, uint8_t reg, uint8_t data);
-
-uint8_t i2cSlaveRead1ByteReg(uint8_t sadd, uint8_t reg);
-uint16_t i2cSlaveRead2ByteReg(uint8_t sadd, uint8_t reg);
-
 long calc_temp_pos(uint16_t reg);
 
 long calc_temp_neg(uint16_t reg);

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -230,3 +230,22 @@ int test_currentsense(uint8_t addr) {
     printf("Current Test Complete\r\n");
     return rtn;
 }
+
+int is_SolarPanel_overcurrent() {
+    // Panel_Alert: N2HET2_0
+    // Panel_SHDN:  N2_HET2_12
+    // Polls for Panel_Alert to go low, then pulls Panel_SHDN low to kill power to
+
+    // Check panel_alert
+    // if (panel_alert is low){
+    //      pull panel SHDN low
+    //      raise error flag
+    //      turn panels back on in ten seconds
+    //                  OR
+    //
+    //  }else{
+    //      return 0;
+    //  }
+    //
+    return 0;
+}

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -16,11 +16,10 @@
 #include <os_task.h>
 #include "printf.h"
 
-uint16_t CALI_REG = 0xDA73; //
-// uint16_t CALI_REG = 0x186;
-uint16_t POWER_OLREG = 0x0100; // adapt me
+uint16_t CALI_REG = 0xDA73;
+uint16_t POWER_OLREG = 0x0100;
 uint16_t ZEROREG = 0x0000;
-uint16_t FFREG = 0x0082;
+uint16_t CONTROL_REG = 0x0082;
 
 int ina209_Write1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t data) {
     uint8_t buf[2];
@@ -190,6 +189,9 @@ void _flip_byte_order(uint16_t *input) {
     return;
 }
 
+/*
+ * Initalize INA209 current sense chip
+ */
 void init_ina209(uint8_t addr) {
     uint16_t retval;
     // clear POR flags
@@ -208,7 +210,7 @@ void init_ina209(uint8_t addr) {
     // ina209_set bit masks
     ina209_set_control_register(addr, &ZEROREG);
     vTaskDelay(2);
-    ina209_set_control_register(addr, &FFREG);
+    ina209_set_control_register(addr, &CONTROL_REG);
 
     ina209_get_power_overlimit(addr, &retval);
 
@@ -222,7 +224,7 @@ void init_ina209(uint8_t addr) {
 void reset_ina209(uint8_t addr) {
     ina209_set_control_register(addr, &ZEROREG);
     vTaskDelay(2);
-    ina209_set_control_register(addr, &FFREG);
+    ina209_set_control_register(addr, &CONTROL_REG);
 }
 
 // int test_currentsense(uint8_t addr) {

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -14,10 +14,11 @@
 #include <i2c_io.h>
 #include <FreeRTOS.h>
 #include <os_task.h>
+#include "printf.h"
 
 uint16_t CALI_REG = 0xDA73;
 uint16_t POWER_OLREG = 0x0100; // adapt me
-uint16_t ZEROREG = 0x0000;
+uint16_t ZEROREG = 0x000;
 uint16_t FFREG = 0xFFFF;
 
 int ina209_Write1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t data) {
@@ -187,13 +188,15 @@ void _flip_byte_order(uint16_t *input) {
 }
 
 void init_ina209(uint8_t addr) {
-    // clear POR flags
     uint16_t retval;
+    // clear POR flags
     for (uint8_t i = 0; i < 5; i++) {
         ina209_get_status_flags(addr, &retval);
     }
     // ina209_set calibration register
-    ina209_set_calibration(addr, &CALI_REG);
+    if (addr == SOLAR_INA209_ADDR) {
+        ina209_set_calibration(addr, &CALI_REG);
+    }
     // ina209_set power overlimit
     ina209_set_power_overlimit(addr, &POWER_OLREG);
     // ina209_set bit masks
@@ -229,23 +232,4 @@ int test_currentsense(uint8_t addr) {
     }
     printf("Current Test Complete\r\n");
     return rtn;
-}
-
-int is_SolarPanel_overcurrent() {
-    // Panel_Alert: N2HET2_0
-    // Panel_SHDN:  N2_HET2_12
-    // Polls for Panel_Alert to go low, then pulls Panel_SHDN low to kill power to
-
-    // Check panel_alert
-    // if (panel_alert is low){
-    //      pull panel SHDN low
-    //      raise error flag
-    //      turn panels back on in ten seconds
-    //                  OR
-    //
-    //  }else{
-    //      return 0;
-    //  }
-    //
-    return 0;
 }

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -20,6 +20,8 @@ uint16_t CALI_REG = 0xDA73;
 uint16_t POWER_OLREG = 0x0100;
 uint16_t ZEROREG = 0x0000;
 uint16_t CONTROL_REG = 0x0082;
+uint16_t BUS_VOLTAGE_OL = 0xFFFC;
+uint16_t BUS_VOLTAGE_UL = 0xFFFF;
 
 int ina209_Write1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t data) {
     uint8_t buf[2];
@@ -50,7 +52,6 @@ int ina209_Read1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t *val) {
 int ina209_Read2ByteReg(uint8_t addr, uint8_t reg_addr, uint16_t *val) {
     // TODO: make this use error code return instead
     uint8_t data[2] = {0};
-    uint16_t value = 0;
 
     if (i2c_Send(i2cREG2, addr, 1, &reg_addr) == -1) {
         return -1;
@@ -64,124 +65,78 @@ int ina209_Read2ByteReg(uint8_t addr, uint8_t reg_addr, uint16_t *val) {
     return 0;
 }
 
-void ina209_get_configuration(uint8_t addr, uint16_t *retval) {
+int ina209_get_configuration(uint8_t addr, uint16_t *retval) {
     // POR is x399F
-    ina209_Read2ByteReg(addr, 0x00, retval);
-    return;
+    return ina209_Read2ByteReg(addr, 0x00, retval);
 }
 
-void ina209_set_configuration(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x00, *val);
-    return;
-}
+int ina209_set_configuration(uint8_t addr, uint16_t *val) { return ina209_Write2ByteReg(addr, 0x00, *val); }
 
-void ina209_get_status_flags(uint8_t addr, uint16_t *retval) {
+int ina209_get_status_flags(uint8_t addr, uint16_t *retval) {
     //  POR is x0000
-    ina209_Read2ByteReg(addr, 0x01, retval);
-    return;
+    return ina209_Read2ByteReg(addr, 0x01, retval);
 }
 
 // probably not needed; designs have alert pin grounded
-void ina209_get_control_register(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x02, retval);
-    return;
-}
+int ina209_get_control_register(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x02, retval); }
 
-void ina209_set_control_register(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x02, *val);
-    return;
-}
+int ina209_set_control_register(uint8_t addr, uint16_t *val) { return ina209_Write2ByteReg(addr, 0x02, *val); }
 
-void ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x03, retval);
-    return;
-}
+int ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x03, retval); }
 
-void ina209_get_bus_voltage(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x04, retval);
-    return;
-}
+int ina209_get_bus_voltage(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x04, retval); }
 
-void ina209_get_power(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x05, retval);
-    return;
-}
+int ina209_get_power(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x05, retval); }
 
 // Current defaults to 0 on POR before calibration register (x16) is ina209_set
-void ina209_get_current(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x06, retval);
-    return;
+int ina209_get_current(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x06, retval); }
+
+int ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x07, retval);
 }
 
-void ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x07, retval);
-    return;
+int ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x08, retval);
 }
 
-void ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x08, retval);
-    return;
+int ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x09, retval);
 }
 
-void ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x09, retval);
-    return;
+int ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x0A, retval);
 }
 
-void ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x0A, retval);
-    return;
+int ina209_get_power_peak(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x0B, retval); }
+
+int ina209_get_power_overlimit(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x11, retval); }
+
+int ina209_set_power_overlimit(uint8_t addr, uint16_t *val) { return ina209_Write2ByteReg(addr, 0x11, *val); }
+
+int ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x12, retval);
 }
 
-void ina209_get_power_peak(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x0B, retval);
-    return;
+int ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t *val) {
+    return ina209_Write2ByteReg(addr, 0x12, *val);
 }
 
-void ina209_get_power_overlimit(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x11, retval);
-    return;
+int ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval) {
+    return ina209_Read2ByteReg(addr, 0x13, retval);
 }
 
-void ina209_set_power_overlimit(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x11, *val);
-    return;
+int ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t *val) {
+    return ina209_Write2ByteReg(addr, 0x13, *val);
 }
 
-void ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x12, retval);
-    return;
-}
+int ina209_get_calibration(uint8_t addr, uint16_t *retval) { return ina209_Read2ByteReg(addr, 0x16, retval); }
 
-void ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x12, *val);
-    return;
-}
-
-void ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x13, retval);
-    return;
-}
-
-void ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x13, *val);
-    return;
-}
-
-void ina209_get_calibration(uint8_t addr, uint16_t *retval) {
-    ina209_Read2ByteReg(addr, 0x16, retval);
-    return;
-}
-
-void ina209_set_calibration(uint8_t addr, uint16_t *val) {
-    ina209_Write2ByteReg(addr, 0x16, *val);
-    return;
-}
+int ina209_set_calibration(uint8_t addr, uint16_t *val) { return ina209_Write2ByteReg(addr, 0x16, *val); }
 
 /*
  * Initalize INA209 current sense chip
  */
-void init_ina209(uint8_t addr) {
+int init_ina209(uint8_t addr) {
     uint16_t retval;
     // clear POR flags
     for (uint8_t i = 0; i < 5; i++) {
@@ -193,8 +148,8 @@ void init_ina209(uint8_t addr) {
     }
     // ina209_set power overlimit
     ina209_set_power_overlimit(addr, &POWER_OLREG);
-    ina209_set_bus_voltage_overlimit(addr, 0xFFFC);
-    ina209_set_bus_voltage_underlimit(addr, 0xFFFF);
+    ina209_set_bus_voltage_overlimit(addr, &BUS_VOLTAGE_OL);
+    ina209_set_bus_voltage_underlimit(addr, &BUS_VOLTAGE_UL);
 
     // ina209_set bit masks
     ina209_set_control_register(addr, &ZEROREG);
@@ -207,13 +162,14 @@ void init_ina209(uint8_t addr) {
     for (uint8_t i = 0; i < 5; i++) {
         ina209_get_status_flags(addr, &retval);
     }
-    return;
+    return 0;
 }
 
-void reset_ina209(uint8_t addr) {
+int reset_ina209(uint8_t addr) {
     ina209_set_control_register(addr, &ZEROREG);
     vTaskDelay(2);
     ina209_set_control_register(addr, &CONTROL_REG);
+    return 0;
 }
 
 // int test_currentsense(uint8_t addr) {

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -1,0 +1,212 @@
+/*
+ *  INA209.c
+ *  Drivers for INA209 Current Sense
+ *  See Datasheet for possible register values
+ *  https://www.ti.com/lit/ds/symlink/ina209.pdf
+ *
+ *  INA209 registers are Most Significant Byte first - LSB PEEPS BEWARE
+ *  (MSB peeps just toss the _flip_byte_order() function)
+ *  Created on: May 10, 2022
+ *  Author: Liam Droog
+ */
+
+#include <ina209.h>
+#include <i2c_io.h>
+#include <FreeRTOS.h>
+#include <os_task.h>
+
+uint16_t CALI_REG =  0xDA73;
+uint16_t POWER_OLREG =  0x0100;
+uint16_t ZEROREG =  0x0000;
+uint16_t FFREG = 0xFFFF;
+
+
+int ina209_Write1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t data) {
+    uint8_t buf[2];
+    buf[0] = reg_addr;
+    buf[1] = data;
+    return i2c_Send(i2cREG2, addr, 2, &buf);
+}
+
+int ina209_Write2ByteReg(uint8_t addr, uint8_t reg_addr, uint16_t data) {
+    uint8_t buf[3];
+    buf[0] = reg_addr;
+    buf[1] = data & 0x00FF;
+    buf[2] = data & 0xFF00;
+    return i2c_Send(i2cREG2, addr, 3, &buf);
+}
+
+int ina209_Read1ByteReg(uint8_t addr, uint8_t reg_addr, uint8_t * val) {
+    // TODO: make this use error code return instead
+    uint8_t value = 0;
+
+    i2c_Send(i2cREG2, addr, 1, &reg_addr);
+
+    i2c_Receive(i2cREG2, addr, 1, &value);
+
+    return value;
+}
+
+int ina209_Read2ByteReg(uint8_t addr, uint8_t reg_addr, uint16_t * val) {
+    // TODO: make this use error code return instead
+    uint8_t data[2] = {0};
+    uint16_t value = 0;
+
+    if(i2c_Send(i2cREG2, addr, 1, &reg_addr) == -1){
+        return -1;
+    }
+
+    if(i2c_Receive(i2cREG2, addr, 2, &data) == -1){
+        return -1;
+    }
+
+    *val = (((uint16_t)(data[0])) << 8) | data[1];
+
+    return 0;
+}
+
+void ina209_get_configuration(uint8_t addr, uint16_t *retval) {
+    // POR is x399F
+    ina209_Read2ByteReg(addr, 0x00, retval);
+    return;
+}
+
+void ina209_set_configuration(uint8_t addr, uint16_t *val) {
+    ina209_Write2ByteReg(addr, 0x00, *val);
+    return;
+}
+
+void ina209_get_status_flags(uint8_t addr, uint16_t *retval) {
+    //  POR is x0000
+    ina209_Read2ByteReg(addr, 0x01, retval);
+    return;
+}
+
+// probably not needed; designs have alert pin grounded
+void ina209_get_control_register(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x02, retval);
+    return;
+}
+
+void ina209_set_control_register(uint8_t addr, uint16_t *val){
+    ina209_Write2ByteReg(addr, 0x02, *val);
+}
+
+void ina209_get_shunt_voltage(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x03, retval);
+    return;
+}
+
+void ina209_get_bus_voltage(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x04, retval);
+    return;
+}
+
+void ina209_get_power(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x05, retval);
+    return;
+}
+
+// Current defaults to 0 on POR before calibration register (x16) is ina209_set
+void ina209_get_current(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x06, retval);
+    return;
+}
+
+void ina209_get_shunt_voltage_peak_pos(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x07, retval);
+    return;
+}
+
+void ina209_get_shunt_voltage_peak_neg(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x08, retval);
+    return;
+}
+
+void ina209_get_bus_voltage_peak_max(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x09, retval);
+    return;
+}
+
+void ina209_get_bus_voltage_peak_min(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x0A, retval);
+    return;
+}
+
+void ina209_get_power_peak(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x0B, retval);
+    return;
+}
+
+void ina209_get_power_overlimit(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x11, retval);
+    return;
+}
+
+void ina209_set_power_overlimit(uint8_t addr, uint16_t *val) {
+    ina209_Write2ByteReg(addr, 0x11, *val);
+    return;
+}
+
+void ina209_get_bus_voltage_overlimit(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x12, retval);
+    return;
+}
+
+void ina209_set_bus_voltage_overlimit(uint8_t addr, uint16_t  *val) {
+    ina209_Write2ByteReg(addr, 0x12, *val);
+    return;
+}
+
+void ina209_get_bus_voltage_underlimit(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x13, retval);
+    return;
+}
+
+void ina209_set_bus_voltage_underlimit(uint8_t addr, uint16_t  *val) {
+    ina209_Write2ByteReg(addr, 0x13, *val);
+    return;
+}
+
+void ina209_get_calibration(uint8_t addr, uint16_t *retval) {
+    ina209_Read2ByteReg(addr, 0x16, retval);
+    return;
+}
+
+void ina209_set_calibration(uint8_t addr, uint16_t *val) {
+    ina209_Write2ByteReg(addr, 0x16, *val);
+    return;
+}
+
+void _flip_byte_order(uint16_t *input) {
+    // Data is transmitted MSB first, but STM is LSB.
+    // This flips the byte order.
+    uint8_t rtn = 0x0000;
+    uint8_t lsb = *input >> 8;
+    uint8_t msb = *input & 0x00FF;
+    rtn = msb << 8 | lsb;
+    *input = rtn;
+    return;
+}
+
+void init_ina209(uint8_t addr){
+    // clear POR flags
+    uint16_t retval;
+    for (uint8_t i=0; i<5; i++){ina209_get_status_flags(addr, &retval);}
+    // ina209_set calibration register
+    ina209_set_calibration(addr, &CALI_REG);
+    // ina209_set power overlimit
+    ina209_set_power_overlimit(addr, &POWER_OLREG);
+    // ina209_set bit masks
+    ina209_set_control_register(addr, &ZEROREG);
+    vTaskDelay(2);
+    ina209_set_control_register(addr, &FFREG);
+    return;
+}
+
+void reset_ina209(uint8_t addr){
+    ina209_set_control_register(addr, &ZEROREG);
+    vTaskDelay(2);
+    ina209_set_control_register(addr, &FFREG);
+}
+

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -178,17 +178,6 @@ void ina209_set_calibration(uint8_t addr, uint16_t *val) {
     return;
 }
 
-void _flip_byte_order(uint16_t *input) {
-    // Data is transmitted MSB first, but STM is LSB.
-    // This flips the byte order.
-    uint8_t rtn = 0x0000;
-    uint8_t lsb = *input >> 8;
-    uint8_t msb = *input & 0x00FF;
-    rtn = msb << 8 | lsb;
-    *input = rtn;
-    return;
-}
-
 /*
  * Initalize INA209 current sense chip
  */

--- a/ex2_hal/athena/equipment_handler/source/ina209.c
+++ b/ex2_hal/athena/equipment_handler/source/ina209.c
@@ -214,6 +214,7 @@ int test_currentsense(uint8_t addr) {
     printf("Initializing INA209\r\n");
     init_ina209(SOLAR_INA209_ADDR);
     vTaskDelay(500);
+
     uint16_t current, current_reg, shunt_voltage;
     // current = (1/4096) * (shunt voltage * calibration register)
     for (int i = 0; i < 30; i++) {

--- a/ex2_hal/athena/hardware_interface/include/hal_athena.h
+++ b/ex2_hal/athena/hardware_interface/include/hal_athena.h
@@ -1,0 +1,15 @@
+/*
+ * hal_athena.h
+ *
+ *  Created on: Jul 18, 2022
+ *      Author: joshd
+ */
+
+#ifndef EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_
+#define EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_
+
+
+
+int initAthena(void);
+
+#endif /* EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_ */

--- a/ex2_hal/athena/hardware_interface/include/hal_athena.h
+++ b/ex2_hal/athena/hardware_interface/include/hal_athena.h
@@ -2,14 +2,21 @@
  * hal_athena.h
  *
  *  Created on: Jul 18, 2022
- *      Author: joshd
+ *      Author: joshd, Liam Droog
  */
+#include "HL_reg_het.h"
+#include <ina209.h>
 
 #ifndef EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_
 #define EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_
 
-
+// ------ Solar Panel Current Sense Pin Definitions ------ //
+#define SOLAR_CURRENTSENSE_ALERT_PIN 0
+#define SOLAR_CURRENTSENSE_ALERT_PORT hetPORT2
+#define SOLAR_CURRENTSENSE_SHDN_PIN 12
+#define SOLAR_CURRENTSENSE_SHDN_PORT hetPORT2
 
 int initAthena(void);
+void is_SolarPanel_overcurrent(void *pvParameters);
 
 #endif /* EX2_HAL_ATHENA_HARDWARE_INTERFACE_INCLUDE_HAL_ATHENA_H_ */

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -2,7 +2,7 @@
  * hal_athena.c
  *
  *  Created on: Jul 18, 2022
- *      Author: joshd
+ *      Author: Liam Droog
  */
 #include <hal_athena.h>
 #include <ina209.h>
@@ -14,29 +14,30 @@ uint32_t is_oc;
 
 int initAthena(void) {
 #if IS_ATHENA_V2 == 1
-
-    // check eeprom flag for is_sensors_fucked
-
     init_ina209(SOLAR_INA209_ADDR);
-
     // set pin high, ensuring FET is allowing current through
     gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 1);
 
-    return 0;
+    // check pin to ensure there isn't an overcurrent event
+    is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
+    if (is_oc != 1) {
+        // pull pin low to cut MOSFET
+        gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
+        sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
 #endif
-}
+        return 0;
+    }
 
-void is_SolarPanel_overcurrent(void *pvParameters) {
-    while (1) {
-        is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
-        if (is_oc != 1) {
-            // pull pin low to cut MOSFET
-            gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
-            sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
-            // add eeprom flag saying panels are effed//
-            vTaskDelete(0);
-        } else {
-            vTaskDelay(300);
+    void is_SolarPanel_overcurrent(void *pvParameters) {
+        while (1) {
+            is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
+            if (is_oc != 1) {
+                // pull pin low to cut MOSFET
+                gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
+                sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
+                vTaskDelete(0);
+            } else {
+                vTaskDelay(300);
+            }
         }
     }
-}

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -8,14 +8,20 @@
 #include <ina209.h>
 #include "HL_gio.h"
 #include "logger.h"
+#include "ina209.h"
 
 uint32_t is_oc;
 
 int initAthena(void) {
 #if IS_ATHENA_V2 == 1
+
+    // check eeprom flag for is_sensors_fucked
+
+    init_ina209(SOLAR_INA209_ADDR);
+
     // set pin high, ensuring FET is allowing current through
     gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 1);
-    init_ina209(SOLAR_INA209_ADDR);
+
     return 0;
 #endif
 }
@@ -27,6 +33,7 @@ void is_SolarPanel_overcurrent(void *pvParameters) {
             // pull pin low to cut MOSFET
             gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
             sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
+            // add eeprom flag saying panels are effed//
             vTaskDelete(0);
         } else {
             vTaskDelay(300);

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -1,0 +1,17 @@
+/*
+ * hal_athena.c
+ *
+ *  Created on: Jul 18, 2022
+ *      Author: joshd
+ */
+#include "ina209.h"
+
+uint16_t SOLAR_INA209_CONFIG  = 0xDA73;
+
+int initAthena(void){
+#if IS_ATHENA_V2 == 1
+    init_ina209(SOLAR_INA209_ADDR);
+    ina209_set_configuration((uint8_t)SOLAR_INA209_ADDR, &SOLAR_INA209_CONFIG);
+    return 0;
+#endif
+}

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -24,9 +24,9 @@ int initAthena(void) {
         // pull pin low to cut MOSFET
         gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
         sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
-#endif
-        return 0;
     }
+#endif
+    return 0;
 }
 
 void is_SolarPanel_overcurrent(void *pvParameters) {

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -4,14 +4,32 @@
  *  Created on: Jul 18, 2022
  *      Author: joshd
  */
-#include "ina209.h"
+#include <hal_athena.h>
+#include <ina209.h>
+#include "HL_gio.h"
+#include "logger.h"
 
-uint16_t SOLAR_INA209_CONFIG  = 0xDA73;
+uint32_t is_oc;
 
-int initAthena(void){
+int initAthena(void) {
 #if IS_ATHENA_V2 == 1
+    // set pin high, ensuring FET is allowing current through
+    gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 1);
     init_ina209(SOLAR_INA209_ADDR);
-    ina209_set_configuration((uint8_t)SOLAR_INA209_ADDR, &SOLAR_INA209_CONFIG);
     return 0;
 #endif
+}
+
+void is_SolarPanel_overcurrent(void *pvParameters) {
+    while (1) {
+        is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
+        if (is_oc != 1) {
+            // pull pin low to cut MOSFET
+            gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
+            sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
+            vTaskDelete(0);
+        } else {
+            vTaskDelay(300);
+        }
+    }
 }

--- a/ex2_hal/athena/hardware_interface/source/hal_athena.c
+++ b/ex2_hal/athena/hardware_interface/source/hal_athena.c
@@ -27,17 +27,18 @@ int initAthena(void) {
 #endif
         return 0;
     }
+}
 
-    void is_SolarPanel_overcurrent(void *pvParameters) {
-        while (1) {
-            is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
-            if (is_oc != 1) {
-                // pull pin low to cut MOSFET
-                gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
-                sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
-                vTaskDelete(0);
-            } else {
-                vTaskDelay(300);
-            }
+void is_SolarPanel_overcurrent(void *pvParameters) {
+    while (1) {
+        is_oc = gioGetBit(SOLAR_CURRENTSENSE_ALERT_PORT, SOLAR_CURRENTSENSE_ALERT_PIN);
+        if (is_oc != 1) {
+            // pull pin low to cut MOSFET
+            gioSetBit(SOLAR_CURRENTSENSE_SHDN_PORT, SOLAR_CURRENTSENSE_SHDN_PIN, 0);
+            sys_log(CRITICAL, "Solar panel overcurrent event occurred.");
+            vTaskDelete(0);
+        } else {
+            vTaskDelay(300);
         }
     }
+}

--- a/ex2_system/source/diagnostic/diagnostic.c
+++ b/ex2_system/source/diagnostic/diagnostic.c
@@ -34,6 +34,7 @@
 #include "logger/logger.h"
 #include "ns_payload.h"
 #include "iris.h"
+#include "hal_athena.h"
 
 static void uhf_watchdog_daemon(void *pvParameters);
 static void sband_watchdog_daemon(void *pvParameters);
@@ -630,6 +631,17 @@ SAT_returnState start_diagnostic_daemon(void) {
         sys_log(ERROR, "FAILED TO CREATE MUTEX payload_watchdog_mtx.\n");
         return SATR_ERROR;
     }
+#endif
+
+#if ATHENA_IS_STUBBED == 0
+#if IS_ATHENA_V2 == 1
+    if (xTaskCreate(is_SolarPanel_overcurrent, "Solar_Panel_Current_Monitor", SOLAR_INA209_STACK_LEN, NULL,
+                    DIAGNOSTIC_TASK_PRIO, NULL) != pdPASS) {
+        sys_log(ERROR, "FAILED TO CREATE TASK: Solar Panel monitor failed to start!");
+        return SATR_ERROR;
+    }
+    sys_log(INFO, "Created Task: Solar Panel Current Monitor.");
+#endif
 #endif
     return SATR_OK;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -50,6 +50,7 @@
 #include "ads7128.h"
 #include "pcal9538a.h"
 #include "skytraq_gps.h"
+#include "hal_athena.h"
 
 #include <FreeRTOS.h>
 #include <os_task.h>
@@ -142,7 +143,7 @@ void ex2_init(void *pvParameters) {
 #endif                                  // ADCS_IS_STUBBED
 
 #if ATHENA_IS_STUBBED == 0
-    // PLACEHOLDER: athena hardware init
+    initAthena();
 #endif
 
 #if EPS_IS_STUBBED == 0
@@ -182,7 +183,6 @@ void ex2_init(void *pvParameters) {
     /* Software Initialization */
 
     /* Start service server, and response server */
-
     init_software();
 
 #if SDR_TEST == 1


### PR DESCRIPTION
Drivers + Diagnostic task for the INA209 chip.
FET is off on boot, and not activated until the INA209 is initalized and ready for action to prevent an overcurrent event from going unnoticed.

Known issues: Power Overlimit register for the 209 is set at a conservative 0x0100. This will be modified later on once we figure out what nominal power draw on the solar_3v3 net is.


Files:

- .cproject: Adds the new Athena hardware interface / equipment handler folders to include path
- ina209.h: Header for ina209 driver functions
- ina209.c: Source for ina209 driver functions. Contains I2C wrapper functions as well as reset / init functions for the IC
- tmp421.h: Not sure why this was changed. Ask Josh.
- tmp421.c: see above
- HAL_athena.h: Header for athena HAL functions
- HAL_athena.c: Source for Athena HAL functions. Contains general Athena init function as well as the current monitoring function.
- Diagnostic.c: Adds current monitor task to run during initialization of diagnostics tasks. Ifdefs for athena iterations included!
- main.c: Include hal_athena.h

Code compiles and is tested on my end with a V2 Athena.

LD