### PR TITLE
Replace free with vPortFree

### DIFF
--- a/ex2_hal/northern_spirit/equipment_handler/source/northern_spirit_handler.c
+++ b/ex2_hal/northern_spirit/equipment_handler/source/northern_spirit_handler.c
@@ -294,7 +294,7 @@ NS_return NS_get_telemetry(ns_telemetry *telemetry) {
     size_t decoded_len;
     unsigned char *decoded_data = base64_decode(response_data, NS_ENCODED_TELEMETRY_DATA_LEN, &decoded_len);
     if ((decoded_data == NULL) || (decoded_len != NS_DECODED_TELEMETRY_DATA_LEN)) {
-        free(decoded_data);
+        vPortFree(decoded_data);
         xSemaphoreGive(ns_command_mutex);
         return NS_FAIL;
     }
@@ -312,7 +312,7 @@ NS_return NS_get_telemetry(ns_telemetry *telemetry) {
     convert_bytes_to_int16(&telemetry->ram_avail, decoded_data[32], decoded_data[33]);
     convert_bytes_to_int16(&telemetry->lowest_img_num, decoded_data[34], decoded_data[35]);
     convert_bytes_to_int16(&telemetry->first_blank_img_num, decoded_data[36], decoded_data[37]);
-    free(decoded_data);
+    vPortFree(decoded_data);
     return return_val;
 }
 

--- a/ex2_hal/northern_spirit/equipment_handler/source/xmodem.c
+++ b/ex2_hal/northern_spirit/equipment_handler/source/xmodem.c
@@ -154,7 +154,7 @@ int xmodemReceive(const unsigned char *dest, int destsz) {
                     int binary_size;
                     void *data = base64_decode(&xbuff[3], count, &binary_size);
                     red_write(fd, data, binary_size);
-                    free(data);
+                    vPortFree(data);
                     len += count;
                 }
                 ++packetno;
@@ -246,7 +246,7 @@ int xmodemTransmit(int32_t filedes, uint64_t filesz) {
                 } else {
                     char *temp = base64_encode(&xbuff[3], bytes_read, &c);
                     memcpy(&xbuff[3], temp, c);
-                    free(temp);
+                    vPortFree(temp);
                 }
                 if (c < bufsz)
                     xbuff[3 + c] = CTRLZ;

--- a/ex2_system/source/sband_sender/sband_sender.c
+++ b/ex2_system/source/sband_sender/sband_sender.c
@@ -64,7 +64,7 @@ void sband_sender(void *pvParameters) {
                 break;
             }
             sdr_sband_tx(&ifdata, ctx.data, ctx.len);
-            free(ctx.data);
+            vPortFree(ctx.data);
         };
         case ENDING: {
             sys_log(INFO, "Ending sband transfer");


### PR DESCRIPTION
This one's on me. Moved too quick and TI's free was causing the freertos heap to get all messed up. 