### PR TITLE
Taylorr/feature/overhaul dfgm telemetry

### DIFF
--- a/ex2_hal/dfgm/equipment_handler/include/dfgm_handler.h
+++ b/ex2_hal/dfgm/equipment_handler/include/dfgm_handler.h
@@ -112,7 +112,6 @@ typedef struct __attribute__((packed)) {
 } dfgm_data_t;
 
 typedef struct {
-    time_t time;
     uint16 coreVoltage;
     uint16 sensorTemp;
     uint16 refTemp;
@@ -125,7 +124,7 @@ typedef struct {
     uint16 reserved2;
     uint16 reserved3;
     uint16 reserved4;
-} dfgm_housekeeping;
+} DFGM_Housekeeping;
 
 struct dfgm_second {
     time_t time;
@@ -150,6 +149,6 @@ void DFGM_init();
 // Functions called in hardware interface
 DFGM_return DFGM_startDataCollection(int givenRuntime);
 DFGM_return DFGM_stopDataCollection();
-DFGM_return DFGM_get_HK(dfgm_housekeeping *hk);
+DFGM_return DFGM_get_HK(DFGM_Housekeeping *hk);
 
 #endif /* DFGM_HANDLER_H */

--- a/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
+++ b/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
@@ -174,8 +174,8 @@ void update_HK(dfgm_data_t const *data) {
  *      along with the packet's time stamp
  * @param dfgm_data_t *data
  *      A DFGM data struct containing both the packet data and time stamp needed to save the samples
- * @param char * fileName
- *      The name of the file you want to save data to
+ * @param int fileFD
+ *      The file handle to write to
  * @return None
  */
 static void savePacket(dfgm_data_t *data, int fileFd) {
@@ -259,8 +259,8 @@ static void shiftSecondPointer(void) { secondPointer[0] = secondPointer[1]; }
  *      that struct directly into the file byte by byte with a time stamp
  * @param struct dfgm_second *second
  *      The second struct that contains the data you want to save
- * @param char * fileName
- *      The name of the file you want to save data to
+ * @param int fileFD
+ *      The file handle to write to
  * @return None
  */
 static void saveSecond(struct dfgm_second *second, int fileFD) {

--- a/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
+++ b/ex2_hal/dfgm/equipment_handler/source/dfgm_handler.c
@@ -362,6 +362,13 @@ void dfgm_rx_task(void *pvParameters) {
             }
         }
 
+        // Get time
+        data.time = RTCMK_Unix_Now();
+
+        // Always save HK if DFGM is on
+        DFGM_convertRaw_HK_data(&(data.packet));
+        update_HK(&data);
+
         // If a runtime is specified, process data
         if (secondsPassed >= DFGM_runtime) {
             DFGM_running = false;
@@ -386,9 +393,6 @@ void dfgm_rx_task(void *pvParameters) {
             }
 
         } else {
-            // Get time
-            data.time = RTCMK_Unix_Now();
-
             if (firstPacketFlag) {
                 if (HZ_100_fd > 0) {
                     red_close(HZ_100_fd);
@@ -422,9 +426,6 @@ void dfgm_rx_task(void *pvParameters) {
             // Save raw (unconverted) 100Hz data from DFGM
             savePacket(&data, HZ_raw_fd);
             DFGM_convertRawMagData(&(data.packet));
-
-            DFGM_convertRaw_HK_data(&(data.packet));
-            update_HK(&data);
 
             // Save 100Hz data to DFGM
             savePacket(&data, HZ_100_fd);

--- a/ex2_hal/dfgm/hardware_interface/include/dfgm.h
+++ b/ex2_hal/dfgm/hardware_interface/include/dfgm.h
@@ -24,21 +24,6 @@
 #include <stdint.h>
 #include <time.h>
 
-typedef struct __attribute__((packed)) {
-    uint16 coreVoltage;
-    uint16 sensorTemp;
-    uint16 refTemp;
-    uint16 boardTemp;
-    uint16 posRailVoltage;
-    uint16 inputVoltage;
-    uint16 refVoltage;
-    uint16 inputCurrent;
-    uint16 reserved1;
-    uint16 reserved2;
-    uint16 reserved3;
-    uint16 reserved4;
-} DFGM_Housekeeping;
-
 DFGM_return HAL_DFGM_run(int32_t givenRuntime);
 DFGM_return HAL_DFGM_stop();
 DFGM_return HAL_DFGM_get_HK(DFGM_Housekeeping *DFGM_hk);

--- a/ex2_hal/dfgm/hardware_interface/source/dfgm.c
+++ b/ex2_hal/dfgm/hardware_interface/source/dfgm.c
@@ -83,20 +83,7 @@ DFGM_return HAL_DFGM_stop() {
 DFGM_return HAL_DFGM_get_HK(DFGM_Housekeeping *DFGM_hk) {
     DFGM_return status;
 #if DFGM_IS_STUBBED == 0
-    dfgm_housekeeping hk;
-    status = DFGM_get_HK(&hk);
-    DFGM_hk->coreVoltage = hk.coreVoltage;
-    DFGM_hk->sensorTemp = hk.sensorTemp;
-    DFGM_hk->refTemp = hk.refTemp;
-    DFGM_hk->boardTemp = hk.boardTemp;
-    DFGM_hk->posRailVoltage = hk.posRailVoltage;
-    DFGM_hk->inputVoltage = hk.inputVoltage;
-    DFGM_hk->refVoltage = hk.refVoltage;
-    DFGM_hk->inputCurrent = hk.inputCurrent;
-    DFGM_hk->reserved1 = hk.reserved1;
-    DFGM_hk->reserved2 = hk.reserved2;
-    DFGM_hk->reserved3 = hk.reserved3;
-    DFGM_hk->reserved4 = hk.reserved4;
+    status = DFGM_get_HK(DFGM_hk);
 #else
     status = IS_STUBBED_DFGM;
 #endif

--- a/ex2_system/include/housekeeping/housekeeping_mocks.h
+++ b/ex2_system/include/housekeeping/housekeeping_mocks.h
@@ -16,6 +16,7 @@
 #include "hyperion.h"
 #include "housekeeping_charon.h"
 #include "dfgm.h"
+#include "dfgm_handler.h"
 #include "northern_spirit_handler.h"
 #include "iris.h"
 


### PR DESCRIPTION
This change stores the most recent DFGM housekeeping in RAM. Now when housekeeping grabs the DFGM HK it will only do RAM operations, no waiting on semaphores or using OS features

I also made the DFGM keep the file handles in memory instead of opening them before every write. I'm not sure if this will work, might need to increase the number of open files reliance edge will allow